### PR TITLE
Ruby supports variable length strings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Tests
+
+on: push
+
+jobs:
+  ci:
+    name: CI
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby:
+          - '3.2.0'
+          - '3.3.0'
+    steps:
+      - uses: actions/checkout@master
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - run: gem install bundler && bundle && bundle exec rake build
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,4 +20,5 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
       - run: gem install bundler && bundle && bundle exec rake build
+      - run: bundle exec rake spec
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - '3.0.0'
+          - '3.1.0'
           - '3.2.0'
           - '3.3.0'
     steps:

--- a/ext/wikitext/parser.c
+++ b/ext/wikitext/parser.c
@@ -2590,7 +2590,7 @@ return_output:
     str_append(parser->output, null_str, 1); // null-terminate
     len = parser->output->len - 1; // don't count null termination
 
-    VALUE out = rb_str_buf_new();
+    VALUE out = rb_str_buf_new(len);
     free(RSTRING_PTR(out));
     RSTRING(out)->as.heap.aux.capa = len;
     RSTRING(out)->as.heap.ptr = parser->output->ptr;

--- a/ext/wikitext/parser.c
+++ b/ext/wikitext/parser.c
@@ -2590,7 +2590,7 @@ return_output:
     str_append(parser->output, null_str, 1); // null-terminate
     len = parser->output->len - 1; // don't count null termination
 
-    VALUE out = rb_str_buf_new(RSTRING_EMBED_LEN_MAX + 1);
+    VALUE out = rb_str_buf_new();
     free(RSTRING_PTR(out));
     RSTRING(out)->as.heap.aux.capa = len;
     RSTRING(out)->as.heap.ptr = parser->output->ptr;

--- a/ext/wikitext/parser.c
+++ b/ext/wikitext/parser.c
@@ -2594,7 +2594,6 @@ return_output:
     free(RSTRING_PTR(out));
     RSTRING(out)->as.heap.aux.capa = len;
     RSTRING(out)->as.heap.ptr = parser->output->ptr;
-    RSTRING(out)->as.heap.len = len;
     parser->output->ptr = NULL; // don't double-free
     return out;
 }


### PR DESCRIPTION
The `RSTRING_EMBED_LEN_MAX` is unnecessary as of ruby/ruby commit 1da2e7fca35dc697d85dd91d2572ab58d08cd3bc