### PR TITLE
fix: resolve UTF-8 parsing failures on ARM architectures

### DIFF
--- a/ext/wikitext/parser.c
+++ b/ext/wikitext/parser.c
@@ -191,9 +191,9 @@ VALUE Wikitext_parser_tokenize(VALUE self, VALUE string)
         return Qnil;
     string = StringValue(string);
     VALUE tokens = rb_ary_new();
-    char *p = RSTRING_PTR(string);
+    unsigned char *p = (unsigned char *)RSTRING_PTR(string);
     long len = RSTRING_LEN(string);
-    char *pe = p + len;
+    unsigned char *pe = p + len;
     token_t token;
     next_token(&token, NULL, p, pe);
     rb_ary_push(tokens, wiki_token(&token));
@@ -211,9 +211,9 @@ VALUE Wikitext_parser_benchmarking_tokenize(VALUE self, VALUE string)
     if (NIL_P(string))
         return Qnil;
     string = StringValue(string);
-    char *p = RSTRING_PTR(string);
+    unsigned char *p = (unsigned char *)RSTRING_PTR(string);
     long len = RSTRING_LEN(string);
-    char *pe = p + len;
+    unsigned char *pe = p + len;
     token_t token;
     next_token(&token, NULL, p, pe);
     while (token.type != END_OF_FILE)
@@ -246,9 +246,9 @@ VALUE Wikitext_parser_fulltext_tokenize(int argc, VALUE *argv, VALUE self)
         min_len = 0;
 
     // set up scanner
-    char *p = RSTRING_PTR(string);
+    unsigned char *p = (unsigned char *)RSTRING_PTR(string);
     long len = RSTRING_LEN(string);
-    char *pe = p + len;
+    unsigned char *pe = p + len;
     token_t token;
     token_t *_token = &token;
     next_token(&token, NULL, p, pe);
@@ -1146,9 +1146,9 @@ VALUE Wikitext_parser_parse(int argc, VALUE *argv, VALUE self)
         base_heading_level = 6;
 
     // set up scanner
-    char *p = RSTRING_PTR(string);
+    unsigned char *p = (unsigned char *)RSTRING_PTR(string);
     long len = RSTRING_LEN(string);
-    char *pe = p + len;
+    unsigned char *pe = p + len;
 
     // set up parser struct to make passing parameters a little easier
     parser_t *parser                = parser_new();

--- a/ext/wikitext/parser.c
+++ b/ext/wikitext/parser.c
@@ -28,6 +28,7 @@
 #include "str.h"
 #include "wikitext.h"
 #include "wikitext_ragel.h"
+#include <ruby/encoding.h>
 
 #define IN(type) ary_includes(parser->scope, type)
 #define IN_EITHER_OF(type1, type2) ary_includes2(parser->scope, type1, type2)
@@ -417,7 +418,17 @@ void wiki_append_sanitized_link_target(str_t *link_target, str_t *output, bool t
             *(output->ptr + output->len) = *src;
             output->len++;
         }
-        else    // all others: must convert to entities
+        else if ((*src & 0x80) != 0)    // UTF-8 multi-byte sequence
+        {
+            // pass through UTF-8 characters unchanged for modern URL support
+            long width;
+            wiki_utf8_to_utf32(src, end, &width);  // validate UTF-8 sequence
+            str_append(output, src, width);
+            src         += width;
+            non_space   = output->ptr + output->len;
+            continue;
+        }
+        else    // all others (control characters): convert to entities
         {
             long        width;
             wiki_append_entity_from_utf32_char(output, wiki_utf8_to_utf32(src, end, &width));
@@ -2563,7 +2574,11 @@ VALUE Wikitext_parser_parse(int argc, VALUE *argv, VALUE self)
                 output = parser->capture ? parser->capture : parser->output;
                 wiki_pop_excess_elements(parser);
                 wiki_start_para_if_necessary(parser);
-                wiki_append_entity_from_utf32_char(output, token->code_point);
+                // When capturing link text in external links, preserve UTF-8 characters
+                if (parser->capture && IN(EXT_LINK_START))
+                    str_append(output, token->start, TOKEN_LEN(token));
+                else
+                    wiki_append_entity_from_utf32_char(output, token->code_point);
                 break;
 
             case END_OF_FILE:
@@ -2596,7 +2611,9 @@ return_output:
     // create a new string (Ruby will copy the data). Ruby has gotten faster
     // over the years anyway, and we can hope that the cost of parsing outweighs
     // the allocation and copying.
-    return rb_str_new(parser->output->ptr, parser->output->len - 1);
+    VALUE out = rb_str_new(parser->output->ptr, parser->output->len - 1);
+    rb_enc_set_index(out, rb_enc_find_index("UTF-8"));
+    return out;
 #else
     // Nasty hack to avoid re-allocating our return value by reaching into Ruby
     // string internals.
@@ -2608,6 +2625,7 @@ return_output:
     RSTRING(out)->as.heap.ptr = parser->output->ptr;
     RSTRING(out)->as.heap.len = len;
     parser->output->ptr = NULL; // Don't double-free.
+    rb_enc_set_index(out, rb_enc_find_index("UTF-8"));
     return out;
 #endif
 }

--- a/ext/wikitext/str.c
+++ b/ext/wikitext/str.c
@@ -22,6 +22,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "str.h"
+#include <ruby/encoding.h>
 
 // when allocating memory, reserve a little more than was asked for,
 // which can help to avoid subsequent allocations
@@ -55,7 +56,7 @@ str_t *str_new_from_string(VALUE string)
 VALUE string_from_str(str_t *str)
 {
     VALUE string = rb_str_new(str->ptr, str->len);
-    rb_funcall(string, rb_intern("force_encoding"), 1, rb_str_new2("UTF-8"));
+    rb_enc_set_index(string, rb_enc_find_index("UTF-8"));
     return string;
 }
 

--- a/ext/wikitext/token.h
+++ b/ext/wikitext/token.h
@@ -29,8 +29,8 @@
 
 typedef struct
 {
-    char        *start;
-    char        *stop;
+    unsigned char *start;
+    unsigned char *stop;
     size_t      line_start;
     size_t      line_stop;
     size_t      column_start;

--- a/ext/wikitext/wikitext_ragel.c
+++ b/ext/wikitext/wikitext_ragel.c
@@ -1,5 +1,5 @@
 
-#line 1 "wikitext_ragel.rl"
+#line 1 "ext/wikitext/wikitext_ragel.rl"
 // Copyright 2008-present Greg Hurrell. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -41,7 +41,7 @@
 #define NEXT_CHAR() (*(p + 1))
 
 
-#line 45 "wikitext_ragel.c"
+#line 45 "ext/wikitext/wikitext_ragel.c"
 static const int wikitext_start = 106;
 static const int wikitext_first_final = 106;
 static const int wikitext_error = 0;
@@ -49,7 +49,7 @@ static const int wikitext_error = 0;
 static const int wikitext_en_main = 106;
 
 
-#line 483 "wikitext_ragel.rl"
+#line 484 "ext/wikitext/wikitext_ragel.rl"
 
 
 // for now we use the scanner as a tokenizer that returns one token at a time, just like ANTLR
@@ -57,7 +57,7 @@ static const int wikitext_en_main = 106;
 // pass in the last token because that's useful for the scanner to know
 // p data pointer (required by Ragel machine); overriden with contents of last_token if supplied
 // pe data end pointer (required by Ragel machine)
-void next_token(token_t *out, token_t *last_token, char *p, char *pe)
+void next_token(token_t *out, token_t *last_token, unsigned char *p, unsigned char *pe)
 {
     int last_token_type = NO_TOKEN;
     if (last_token)
@@ -85,14 +85,14 @@ void next_token(token_t *out, token_t *last_token, char *p, char *pe)
         return;
     }
 
-    char    *mark;      // for manual backtracking
-    char    *eof = pe;  // required for backtracking (longest match determination)
+    unsigned char *mark;      // for manual backtracking
+    unsigned char *eof = pe;  // required for backtracking (longest match determination)
     int     cs;         // current state (standard Ragel)
-    char    *ts;        // token start (scanner)
-    char    *te;        // token end (scanner)
+    unsigned char *ts;        // token start (scanner)
+    unsigned char *te;        // token end (scanner)
     int     act;        // identity of last patterned matched (scanner)
     
-#line 96 "wikitext_ragel.c"
+#line 96 "ext/wikitext/wikitext_ragel.c"
 	{
 	cs = wikitext_start;
 	ts = 0;
@@ -100,99 +100,57 @@ void next_token(token_t *out, token_t *last_token, char *p, char *pe)
 	act = 0;
 	}
 
-#line 525 "wikitext_ragel.rl"
+#line 526 "ext/wikitext/wikitext_ragel.rl"
     
-#line 106 "wikitext_ragel.c"
+#line 106 "ext/wikitext/wikitext_ragel.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
 	switch ( cs )
 	{
 tr0:
-#line 55 "wikitext_ragel.rl"
-	{
-        out->code_point = ((uint32_t)(*(p - 1)) & 0x1f) << 6 |
-            (*p & 0x3f);
-    }
-#line 474 "wikitext_ragel.rl"
-	{te = p+1;{
-            EMIT(DEFAULT);
-            out->column_stop = out->column_start + 1;
-            {p++; cs = 106; goto _out;}
-        }}
-	goto st106;
-tr3:
-#line 61 "wikitext_ragel.rl"
-	{
-        out->code_point = ((uint32_t)(*(p - 2)) & 0x0f) << 12 |
-            ((uint32_t)(*(p - 1)) & 0x3f) << 6 |
-            (*p & 0x3f);
-    }
-#line 474 "wikitext_ragel.rl"
-	{te = p+1;{
-            EMIT(DEFAULT);
-            out->column_stop = out->column_start + 1;
-            {p++; cs = 106; goto _out;}
-        }}
-	goto st106;
-tr6:
-#line 68 "wikitext_ragel.rl"
-	{
-        out->code_point = ((uint32_t)(*(p - 3)) & 0x07) << 18 |
-            ((uint32_t)(*(p - 2)) & 0x3f) << 12 |
-            ((uint32_t)(*(p - 1)) & 0x3f) << 6 |
-            (*p & 0x3f);
-    }
-#line 474 "wikitext_ragel.rl"
-	{te = p+1;{
-            EMIT(DEFAULT);
-            out->column_stop = out->column_start + 1;
-            {p++; cs = 106; goto _out;}
-        }}
-	goto st106;
-tr7:
-#line 381 "wikitext_ragel.rl"
+#line 382 "ext/wikitext/wikitext_ragel.rl"
 	{{p = ((te))-1;}{
             EMIT(AMP);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
-tr10:
-#line 369 "wikitext_ragel.rl"
+tr3:
+#line 370 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(DECIMAL_ENTITY);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
-tr12:
-#line 363 "wikitext_ragel.rl"
+tr5:
+#line 364 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(HEX_ENTITY);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
-tr14:
-#line 357 "wikitext_ragel.rl"
+tr7:
+#line 358 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(NAMED_ENTITY);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
-tr18:
-#line 351 "wikitext_ragel.rl"
+tr11:
+#line 352 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(AMP_ENTITY);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
-tr22:
-#line 345 "wikitext_ragel.rl"
+tr15:
+#line 346 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(QUOT_ENTITY);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
-tr23:
+tr16:
 #line 1 "NONE"
 	{	switch( act ) {
 	case 21:
@@ -228,152 +186,194 @@ tr23:
 	}
 	}
 	goto st106;
-tr30:
-#line 387 "wikitext_ragel.rl"
+tr23:
+#line 388 "ext/wikitext/wikitext_ragel.rl"
 	{{p = ((te))-1;}{
             EMIT(LESS);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
-tr46:
-#line 126 "wikitext_ragel.rl"
+tr39:
+#line 127 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(BLOCKQUOTE_END);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
-tr48:
-#line 168 "wikitext_ragel.rl"
+tr41:
+#line 169 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(EM_END);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
-tr54:
-#line 96 "wikitext_ragel.rl"
+tr47:
+#line 97 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(NO_WIKI_END);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
-tr57:
-#line 114 "wikitext_ragel.rl"
+tr50:
+#line 115 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(PRE_END);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
-tr63:
-#line 156 "wikitext_ragel.rl"
+tr56:
+#line 157 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(STRONG_END);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
-tr65:
-#line 186 "wikitext_ragel.rl"
+tr58:
+#line 187 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(TT_END);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
-tr75:
-#line 120 "wikitext_ragel.rl"
+tr68:
+#line 121 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(BLOCKQUOTE_START);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
-tr77:
-#line 162 "wikitext_ragel.rl"
+tr70:
+#line 163 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(EM_START);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
-tr83:
-#line 90 "wikitext_ragel.rl"
+tr76:
+#line 91 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(NO_WIKI_START);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
-tr86:
-#line 102 "wikitext_ragel.rl"
+tr79:
+#line 103 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(PRE_START);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
-tr92:
-#line 150 "wikitext_ragel.rl"
+tr85:
+#line 151 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(STRONG_START);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
-tr94:
-#line 180 "wikitext_ragel.rl"
+tr87:
+#line 181 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(TT_START);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
-tr106:
-#line 108 "wikitext_ragel.rl"
+tr99:
+#line 109 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(PRE_START);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
-tr107:
-#line 442 "wikitext_ragel.rl"
+tr100:
+#line 443 "ext/wikitext/wikitext_ragel.rl"
 	{{p = ((te))-1;}{
             EMIT(ALNUM);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
-tr111:
-#line 297 "wikitext_ragel.rl"
+tr104:
+#line 298 "ext/wikitext/wikitext_ragel.rl"
 	{{p = ((te))-1;}{
             EMIT(URI);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
-tr122:
-#line 50 "wikitext_ragel.rl"
+tr112:
+#line 56 "ext/wikitext/wikitext_ragel.rl"
 	{
-        out->code_point = *p & 0x7f;
+        out->code_point = ((uint32_t)(*(p - 1)) & 0x1f) << 6 |
+            (*p & 0x3f);
     }
-#line 474 "wikitext_ragel.rl"
+#line 475 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(DEFAULT);
             out->column_stop = out->column_start + 1;
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
-tr123:
-#line 423 "wikitext_ragel.rl"
+tr115:
+#line 62 "ext/wikitext/wikitext_ragel.rl"
+	{
+        out->code_point = ((uint32_t)(*(p - 2)) & 0x0f) << 12 |
+            ((uint32_t)(*(p - 1)) & 0x3f) << 6 |
+            (*p & 0x3f);
+    }
+#line 475 "ext/wikitext/wikitext_ragel.rl"
+	{te = p+1;{
+            EMIT(DEFAULT);
+            out->column_stop = out->column_start + 1;
+            {p++; cs = 106; goto _out;}
+        }}
+	goto st106;
+tr118:
+#line 69 "ext/wikitext/wikitext_ragel.rl"
+	{
+        out->code_point = ((uint32_t)(*(p - 3)) & 0x07) << 18 |
+            ((uint32_t)(*(p - 2)) & 0x3f) << 12 |
+            ((uint32_t)(*(p - 1)) & 0x3f) << 6 |
+            (*p & 0x3f);
+    }
+#line 475 "ext/wikitext/wikitext_ragel.rl"
+	{te = p+1;{
+            EMIT(DEFAULT);
+            out->column_stop = out->column_start + 1;
+            {p++; cs = 106; goto _out;}
+        }}
+	goto st106;
+tr119:
+#line 51 "ext/wikitext/wikitext_ragel.rl"
+	{
+        out->code_point = *p & 0x7f;
+    }
+#line 475 "ext/wikitext/wikitext_ragel.rl"
+	{te = p+1;{
+            EMIT(DEFAULT);
+            out->column_stop = out->column_start + 1;
+            {p++; cs = 106; goto _out;}
+        }}
+	goto st106;
+tr120:
+#line 424 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(CRLF);
             out->column_stop = 1;
             out->line_stop++;
             {p++; cs = 106; goto _out;}
         }}
-#line 50 "wikitext_ragel.rl"
+#line 51 "ext/wikitext/wikitext_ragel.rl"
 	{
         out->code_point = *p & 0x7f;
     }
 	goto st106;
-tr127:
-#line 375 "wikitext_ragel.rl"
+tr124:
+#line 376 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(QUOT);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
-tr128:
-#line 218 "wikitext_ragel.rl"
+tr125:
+#line 219 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             if (out->column_start == 1              ||
                 last_token_type == OL               ||
@@ -386,8 +386,8 @@ tr128:
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
-tr132:
-#line 231 "wikitext_ragel.rl"
+tr129:
+#line 232 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             if (out->column_start == 1              ||
                 last_token_type == OL               ||
@@ -400,22 +400,22 @@ tr132:
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
-tr146:
-#line 174 "wikitext_ragel.rl"
+tr143:
+#line 175 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(TT);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
-tr148:
-#line 327 "wikitext_ragel.rl"
+tr145:
+#line 328 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(SEPARATOR);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
 tr150:
-#line 423 "wikitext_ragel.rl"
+#line 424 "ext/wikitext/wikitext_ragel.rl"
 	{te = p;p--;{
             EMIT(CRLF);
             out->column_stop = 1;
@@ -424,7 +424,7 @@ tr150:
         }}
 	goto st106;
 tr151:
-#line 423 "wikitext_ragel.rl"
+#line 424 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(CRLF);
             out->column_stop = 1;
@@ -433,7 +433,7 @@ tr151:
         }}
 	goto st106;
 tr152:
-#line 206 "wikitext_ragel.rl"
+#line 207 "ext/wikitext/wikitext_ragel.rl"
 	{te = p;p--;{
             if (out->column_start == 1 || last_token_type == BLOCKQUOTE)
             {
@@ -446,28 +446,28 @@ tr152:
         }}
 	goto st106;
 tr154:
-#line 436 "wikitext_ragel.rl"
+#line 437 "ext/wikitext/wikitext_ragel.rl"
 	{te = p;p--;{
             EMIT(SPECIAL_URI_CHARS);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
 tr155:
-#line 454 "wikitext_ragel.rl"
+#line 455 "ext/wikitext/wikitext_ragel.rl"
 	{te = p;p--;{
             EMIT(PRINTABLE);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
 tr156:
-#line 381 "wikitext_ragel.rl"
+#line 382 "ext/wikitext/wikitext_ragel.rl"
 	{te = p;p--;{
             EMIT(AMP);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
 tr160:
-#line 132 "wikitext_ragel.rl"
+#line 133 "ext/wikitext/wikitext_ragel.rl"
 	{te = p;p--;{
             if (DISTANCE() == 5)
                 EMIT(STRONG_EM);
@@ -486,7 +486,7 @@ tr160:
         }}
 	goto st106;
 tr164:
-#line 132 "wikitext_ragel.rl"
+#line 133 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             if (DISTANCE() == 5)
                 EMIT(STRONG_EM);
@@ -505,35 +505,35 @@ tr164:
         }}
 	goto st106;
 tr166:
-#line 303 "wikitext_ragel.rl"
+#line 304 "ext/wikitext/wikitext_ragel.rl"
 	{te = p;p--;{
             EMIT(MAIL);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
 tr170:
-#line 309 "wikitext_ragel.rl"
+#line 310 "ext/wikitext/wikitext_ragel.rl"
 	{te = p;p--;{
             EMIT(PATH);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
 tr174:
-#line 442 "wikitext_ragel.rl"
+#line 443 "ext/wikitext/wikitext_ragel.rl"
 	{te = p;p--;{
             EMIT(ALNUM);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
 tr175:
-#line 387 "wikitext_ragel.rl"
+#line 388 "ext/wikitext/wikitext_ragel.rl"
 	{te = p;p--;{
             EMIT(LESS);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
 tr184:
-#line 244 "wikitext_ragel.rl"
+#line 245 "ext/wikitext/wikitext_ragel.rl"
 	{te = p;p--;{
             if (out->column_start == 1 || last_token_type == BLOCKQUOTE || last_token_type == BLOCKQUOTE_START)
             {
@@ -587,7 +587,7 @@ tr184:
         }}
 	goto st106;
 tr186:
-#line 193 "wikitext_ragel.rl"
+#line 194 "ext/wikitext/wikitext_ragel.rl"
 	{te = p;p--;{
             if (out->column_start == 1 || last_token_type == BLOCKQUOTE)
                 EMIT(BLOCKQUOTE);
@@ -600,7 +600,7 @@ tr186:
         }}
 	goto st106;
 tr187:
-#line 193 "wikitext_ragel.rl"
+#line 194 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             if (out->column_start == 1 || last_token_type == BLOCKQUOTE)
                 EMIT(BLOCKQUOTE);
@@ -613,63 +613,63 @@ tr187:
         }}
 	goto st106;
 tr191:
-#line 297 "wikitext_ragel.rl"
+#line 298 "ext/wikitext/wikitext_ragel.rl"
 	{te = p;p--;{
             EMIT(URI);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
 tr205:
-#line 333 "wikitext_ragel.rl"
+#line 334 "ext/wikitext/wikitext_ragel.rl"
 	{te = p;p--;{
             EMIT(EXT_LINK_START);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
 tr206:
-#line 315 "wikitext_ragel.rl"
+#line 316 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(LINK_START);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
 tr207:
-#line 339 "wikitext_ragel.rl"
+#line 340 "ext/wikitext/wikitext_ragel.rl"
 	{te = p;p--;{
             EMIT(EXT_LINK_END);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
 tr208:
-#line 321 "wikitext_ragel.rl"
+#line 322 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(LINK_END);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
 tr209:
-#line 411 "wikitext_ragel.rl"
+#line 412 "ext/wikitext/wikitext_ragel.rl"
 	{te = p;p--;{
             EMIT(LEFT_CURLY);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
 tr210:
-#line 399 "wikitext_ragel.rl"
+#line 400 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(IMG_START);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
 tr211:
-#line 417 "wikitext_ragel.rl"
+#line 418 "ext/wikitext/wikitext_ragel.rl"
 	{te = p;p--;{
             EMIT(RIGHT_CURLY);
             {p++; cs = 106; goto _out;}
         }}
 	goto st106;
 tr212:
-#line 405 "wikitext_ragel.rl"
+#line 406 "ext/wikitext/wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(IMG_END);
             {p++; cs = 106; goto _out;}
@@ -683,119 +683,77 @@ st106:
 case 106:
 #line 1 "NONE"
 	{ts = p;}
-#line 687 "wikitext_ragel.c"
+#line 687 "ext/wikitext/wikitext_ragel.c"
 	switch( (*p) ) {
-		case 10: goto tr123;
-		case 13: goto tr124;
-		case 32: goto tr125;
-		case 33: goto st109;
-		case 34: goto tr127;
-		case 35: goto tr128;
-		case 38: goto tr130;
-		case 39: goto st112;
-		case 42: goto tr132;
-		case 43: goto st110;
-		case 45: goto tr133;
-		case 46: goto tr134;
-		case 47: goto st123;
-		case 60: goto tr137;
-		case 61: goto tr138;
-		case 62: goto tr139;
-		case 64: goto st110;
-		case 70: goto tr140;
-		case 72: goto tr141;
-		case 77: goto tr142;
-		case 83: goto tr143;
-		case 91: goto st152;
-		case 92: goto st110;
-		case 93: goto st153;
-		case 94: goto st110;
-		case 95: goto tr133;
-		case 96: goto tr146;
-		case 102: goto tr140;
-		case 104: goto tr141;
-		case 109: goto tr142;
-		case 115: goto tr143;
-		case 123: goto st154;
-		case 124: goto tr148;
-		case 125: goto st155;
-		case 126: goto st110;
-		case 127: goto tr122;
+		case 10u: goto tr120;
+		case 13u: goto tr121;
+		case 32u: goto tr122;
+		case 33u: goto st109;
+		case 34u: goto tr124;
+		case 35u: goto tr125;
+		case 38u: goto tr127;
+		case 39u: goto st112;
+		case 42u: goto tr129;
+		case 43u: goto st110;
+		case 45u: goto tr130;
+		case 46u: goto tr131;
+		case 47u: goto st123;
+		case 60u: goto tr134;
+		case 61u: goto tr135;
+		case 62u: goto tr136;
+		case 64u: goto st110;
+		case 70u: goto tr137;
+		case 72u: goto tr138;
+		case 77u: goto tr139;
+		case 83u: goto tr140;
+		case 91u: goto st152;
+		case 92u: goto st110;
+		case 93u: goto st153;
+		case 94u: goto st110;
+		case 95u: goto tr130;
+		case 96u: goto tr143;
+		case 102u: goto tr137;
+		case 104u: goto tr138;
+		case 109u: goto tr139;
+		case 115u: goto tr140;
+		case 123u: goto st154;
+		case 124u: goto tr145;
+		case 125u: goto st155;
+		case 126u: goto st110;
+		case 127u: goto tr119;
 	}
-	if ( (*p) < 36 ) {
-		if ( (*p) < -32 ) {
-			if ( -62 <= (*p) && (*p) <= -33 )
-				goto st1;
-		} else if ( (*p) > -17 ) {
-			if ( (*p) > -12 ) {
-				if ( 1 <= (*p) && (*p) <= 31 )
-					goto tr122;
-			} else if ( (*p) >= -16 )
-				goto st4;
-		} else
-			goto st2;
-	} else if ( (*p) > 37 ) {
-		if ( (*p) < 48 ) {
-			if ( 40 <= (*p) && (*p) <= 44 )
-				goto st109;
-		} else if ( (*p) > 57 ) {
-			if ( (*p) > 63 ) {
-				if ( 65 <= (*p) && (*p) <= 122 )
-					goto tr136;
-			} else if ( (*p) >= 58 )
+	if ( (*p) < 58u ) {
+		if ( (*p) < 36u ) {
+			if ( 1u <= (*p) && (*p) <= 31u )
+				goto tr119;
+		} else if ( (*p) > 37u ) {
+			if ( (*p) > 44u ) {
+				if ( 48u <= (*p) && (*p) <= 57u )
+					goto tr133;
+			} else if ( (*p) >= 40u )
 				goto st109;
 		} else
-			goto tr136;
+			goto st110;
+	} else if ( (*p) > 63u ) {
+		if ( (*p) < 194u ) {
+			if ( 65u <= (*p) && (*p) <= 122u )
+				goto tr133;
+		} else if ( (*p) > 223u ) {
+			if ( (*p) > 239u ) {
+				if ( 240u <= (*p) && (*p) <= 244u )
+					goto st103;
+			} else if ( (*p) >= 224u )
+				goto st101;
+		} else
+			goto st100;
 	} else
-		goto st110;
+		goto st109;
 	goto st0;
 st0:
 cs = 0;
 	goto _out;
-st1:
-	if ( ++p == pe )
-		goto _test_eof1;
-case 1:
-	if ( (*p) <= -65 )
-		goto tr0;
-	goto st0;
-st2:
-	if ( ++p == pe )
-		goto _test_eof2;
-case 2:
-	if ( (*p) <= -65 )
-		goto st3;
-	goto st0;
-st3:
-	if ( ++p == pe )
-		goto _test_eof3;
-case 3:
-	if ( (*p) <= -65 )
-		goto tr3;
-	goto st0;
-st4:
-	if ( ++p == pe )
-		goto _test_eof4;
-case 4:
-	if ( (*p) <= -65 )
-		goto st5;
-	goto st0;
-st5:
-	if ( ++p == pe )
-		goto _test_eof5;
-case 5:
-	if ( (*p) <= -65 )
-		goto st6;
-	goto st0;
-st6:
-	if ( ++p == pe )
-		goto _test_eof6;
-case 6:
-	if ( (*p) <= -65 )
-		goto tr6;
-	goto st0;
-tr124:
-#line 50 "wikitext_ragel.rl"
+tr121:
+#line 51 "ext/wikitext/wikitext_ragel.rl"
 	{
         out->code_point = *p & 0x7f;
     }
@@ -804,12 +762,12 @@ st107:
 	if ( ++p == pe )
 		goto _test_eof107;
 case 107:
-#line 808 "wikitext_ragel.c"
-	if ( (*p) == 10 )
+#line 766 "ext/wikitext/wikitext_ragel.c"
+	if ( (*p) == 10u )
 		goto tr151;
 	goto tr150;
-tr125:
-#line 45 "wikitext_ragel.rl"
+tr122:
+#line 46 "ext/wikitext/wikitext_ragel.rl"
 	{
         MARK();
     }
@@ -818,8 +776,8 @@ st108:
 	if ( ++p == pe )
 		goto _test_eof108;
 case 108:
-#line 822 "wikitext_ragel.c"
-	if ( (*p) == 32 )
+#line 780 "ext/wikitext/wikitext_ragel.c"
+	if ( (*p) == 32u )
 		goto st108;
 	goto tr152;
 st109:
@@ -827,15 +785,15 @@ st109:
 		goto _test_eof109;
 case 109:
 	switch( (*p) ) {
-		case 33: goto st109;
-		case 44: goto st109;
-		case 46: goto st109;
-		case 63: goto st109;
+		case 33u: goto st109;
+		case 44u: goto st109;
+		case 46u: goto st109;
+		case 63u: goto st109;
 	}
-	if ( (*p) > 41 ) {
-		if ( 58 <= (*p) && (*p) <= 59 )
+	if ( (*p) > 41u ) {
+		if ( 58u <= (*p) && (*p) <= 59u )
 			goto st109;
-	} else if ( (*p) >= 40 )
+	} else if ( (*p) >= 40u )
 		goto st109;
 	goto tr154;
 st110:
@@ -843,20 +801,20 @@ st110:
 		goto _test_eof110;
 case 110:
 	switch( (*p) ) {
-		case 43: goto st110;
-		case 45: goto st110;
-		case 47: goto st110;
-		case 64: goto st110;
-		case 92: goto st110;
-		case 126: goto st110;
+		case 43u: goto st110;
+		case 45u: goto st110;
+		case 47u: goto st110;
+		case 64u: goto st110;
+		case 92u: goto st110;
+		case 126u: goto st110;
 	}
-	if ( (*p) > 37 ) {
-		if ( 94 <= (*p) && (*p) <= 95 )
+	if ( (*p) > 37u ) {
+		if ( 94u <= (*p) && (*p) <= 95u )
 			goto st110;
-	} else if ( (*p) >= 36 )
+	} else if ( (*p) >= 36u )
 		goto st110;
 	goto tr155;
-tr130:
+tr127:
 #line 1 "NONE"
 	{te = p+1;}
 	goto st111;
@@ -864,360 +822,360 @@ st111:
 	if ( ++p == pe )
 		goto _test_eof111;
 case 111:
-#line 868 "wikitext_ragel.c"
+#line 826 "ext/wikitext/wikitext_ragel.c"
 	switch( (*p) ) {
-		case 35: goto st7;
-		case 97: goto st13;
-		case 113: goto st16;
+		case 35u: goto st1;
+		case 97u: goto st7;
+		case 113u: goto st10;
 	}
-	if ( (*p) > 90 ) {
-		if ( 98 <= (*p) && (*p) <= 122 )
-			goto st11;
-	} else if ( (*p) >= 65 )
-		goto st11;
+	if ( (*p) > 90u ) {
+		if ( 98u <= (*p) && (*p) <= 122u )
+			goto st5;
+	} else if ( (*p) >= 65u )
+		goto st5;
 	goto tr156;
+st1:
+	if ( ++p == pe )
+		goto _test_eof1;
+case 1:
+	switch( (*p) ) {
+		case 88u: goto st3;
+		case 120u: goto st3;
+	}
+	if ( 48u <= (*p) && (*p) <= 57u )
+		goto st2;
+	goto tr0;
+st2:
+	if ( ++p == pe )
+		goto _test_eof2;
+case 2:
+	if ( (*p) == 59u )
+		goto tr3;
+	if ( 48u <= (*p) && (*p) <= 57u )
+		goto st2;
+	goto tr0;
+st3:
+	if ( ++p == pe )
+		goto _test_eof3;
+case 3:
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st4;
+	} else if ( (*p) > 70u ) {
+		if ( 97u <= (*p) && (*p) <= 102u )
+			goto st4;
+	} else
+		goto st4;
+	goto tr0;
+st4:
+	if ( ++p == pe )
+		goto _test_eof4;
+case 4:
+	if ( (*p) == 59u )
+		goto tr5;
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st4;
+	} else if ( (*p) > 70u ) {
+		if ( 97u <= (*p) && (*p) <= 102u )
+			goto st4;
+	} else
+		goto st4;
+	goto tr0;
+st5:
+	if ( ++p == pe )
+		goto _test_eof5;
+case 5:
+	if ( (*p) == 59u )
+		goto tr7;
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st6;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
+			goto st5;
+	} else
+		goto st5;
+	goto tr0;
+st6:
+	if ( ++p == pe )
+		goto _test_eof6;
+case 6:
+	if ( (*p) == 59u )
+		goto tr7;
+	if ( 48u <= (*p) && (*p) <= 57u )
+		goto st6;
+	goto tr0;
 st7:
 	if ( ++p == pe )
 		goto _test_eof7;
 case 7:
 	switch( (*p) ) {
-		case 88: goto st9;
-		case 120: goto st9;
+		case 59u: goto tr7;
+		case 109u: goto st8;
 	}
-	if ( 48 <= (*p) && (*p) <= 57 )
-		goto st8;
-	goto tr7;
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st6;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
+			goto st5;
+	} else
+		goto st5;
+	goto tr0;
 st8:
 	if ( ++p == pe )
 		goto _test_eof8;
 case 8:
-	if ( (*p) == 59 )
-		goto tr10;
-	if ( 48 <= (*p) && (*p) <= 57 )
-		goto st8;
-	goto tr7;
+	switch( (*p) ) {
+		case 59u: goto tr7;
+		case 112u: goto st9;
+	}
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st6;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
+			goto st5;
+	} else
+		goto st5;
+	goto tr0;
 st9:
 	if ( ++p == pe )
 		goto _test_eof9;
 case 9:
-	if ( (*p) < 65 ) {
-		if ( 48 <= (*p) && (*p) <= 57 )
-			goto st10;
-	} else if ( (*p) > 70 ) {
-		if ( 97 <= (*p) && (*p) <= 102 )
-			goto st10;
+	if ( (*p) == 59u )
+		goto tr11;
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st6;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
+			goto st5;
 	} else
-		goto st10;
-	goto tr7;
+		goto st5;
+	goto tr0;
 st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-	if ( (*p) == 59 )
-		goto tr12;
-	if ( (*p) < 65 ) {
-		if ( 48 <= (*p) && (*p) <= 57 )
-			goto st10;
-	} else if ( (*p) > 70 ) {
-		if ( 97 <= (*p) && (*p) <= 102 )
-			goto st10;
+	switch( (*p) ) {
+		case 59u: goto tr7;
+		case 117u: goto st11;
+	}
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st6;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
+			goto st5;
 	} else
-		goto st10;
-	goto tr7;
+		goto st5;
+	goto tr0;
 st11:
 	if ( ++p == pe )
 		goto _test_eof11;
 case 11:
-	if ( (*p) == 59 )
-		goto tr14;
-	if ( (*p) < 65 ) {
-		if ( 48 <= (*p) && (*p) <= 57 )
-			goto st12;
-	} else if ( (*p) > 90 ) {
-		if ( 97 <= (*p) && (*p) <= 122 )
-			goto st11;
+	switch( (*p) ) {
+		case 59u: goto tr7;
+		case 111u: goto st12;
+	}
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st6;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
+			goto st5;
 	} else
-		goto st11;
-	goto tr7;
+		goto st5;
+	goto tr0;
 st12:
 	if ( ++p == pe )
 		goto _test_eof12;
 case 12:
-	if ( (*p) == 59 )
-		goto tr14;
-	if ( 48 <= (*p) && (*p) <= 57 )
-		goto st12;
-	goto tr7;
+	switch( (*p) ) {
+		case 59u: goto tr7;
+		case 116u: goto st13;
+	}
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st6;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
+			goto st5;
+	} else
+		goto st5;
+	goto tr0;
 st13:
 	if ( ++p == pe )
 		goto _test_eof13;
 case 13:
-	switch( (*p) ) {
-		case 59: goto tr14;
-		case 109: goto st14;
-	}
-	if ( (*p) < 65 ) {
-		if ( 48 <= (*p) && (*p) <= 57 )
-			goto st12;
-	} else if ( (*p) > 90 ) {
-		if ( 97 <= (*p) && (*p) <= 122 )
-			goto st11;
+	if ( (*p) == 59u )
+		goto tr15;
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st6;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
+			goto st5;
 	} else
-		goto st11;
-	goto tr7;
-st14:
-	if ( ++p == pe )
-		goto _test_eof14;
-case 14:
-	switch( (*p) ) {
-		case 59: goto tr14;
-		case 112: goto st15;
-	}
-	if ( (*p) < 65 ) {
-		if ( 48 <= (*p) && (*p) <= 57 )
-			goto st12;
-	} else if ( (*p) > 90 ) {
-		if ( 97 <= (*p) && (*p) <= 122 )
-			goto st11;
-	} else
-		goto st11;
-	goto tr7;
-st15:
-	if ( ++p == pe )
-		goto _test_eof15;
-case 15:
-	if ( (*p) == 59 )
-		goto tr18;
-	if ( (*p) < 65 ) {
-		if ( 48 <= (*p) && (*p) <= 57 )
-			goto st12;
-	} else if ( (*p) > 90 ) {
-		if ( 97 <= (*p) && (*p) <= 122 )
-			goto st11;
-	} else
-		goto st11;
-	goto tr7;
-st16:
-	if ( ++p == pe )
-		goto _test_eof16;
-case 16:
-	switch( (*p) ) {
-		case 59: goto tr14;
-		case 117: goto st17;
-	}
-	if ( (*p) < 65 ) {
-		if ( 48 <= (*p) && (*p) <= 57 )
-			goto st12;
-	} else if ( (*p) > 90 ) {
-		if ( 97 <= (*p) && (*p) <= 122 )
-			goto st11;
-	} else
-		goto st11;
-	goto tr7;
-st17:
-	if ( ++p == pe )
-		goto _test_eof17;
-case 17:
-	switch( (*p) ) {
-		case 59: goto tr14;
-		case 111: goto st18;
-	}
-	if ( (*p) < 65 ) {
-		if ( 48 <= (*p) && (*p) <= 57 )
-			goto st12;
-	} else if ( (*p) > 90 ) {
-		if ( 97 <= (*p) && (*p) <= 122 )
-			goto st11;
-	} else
-		goto st11;
-	goto tr7;
-st18:
-	if ( ++p == pe )
-		goto _test_eof18;
-case 18:
-	switch( (*p) ) {
-		case 59: goto tr14;
-		case 116: goto st19;
-	}
-	if ( (*p) < 65 ) {
-		if ( 48 <= (*p) && (*p) <= 57 )
-			goto st12;
-	} else if ( (*p) > 90 ) {
-		if ( 97 <= (*p) && (*p) <= 122 )
-			goto st11;
-	} else
-		goto st11;
-	goto tr7;
-st19:
-	if ( ++p == pe )
-		goto _test_eof19;
-case 19:
-	if ( (*p) == 59 )
-		goto tr22;
-	if ( (*p) < 65 ) {
-		if ( 48 <= (*p) && (*p) <= 57 )
-			goto st12;
-	} else if ( (*p) > 90 ) {
-		if ( 97 <= (*p) && (*p) <= 122 )
-			goto st11;
-	} else
-		goto st11;
-	goto tr7;
+		goto st5;
+	goto tr0;
 st112:
 	if ( ++p == pe )
 		goto _test_eof112;
 case 112:
-	if ( (*p) == 39 )
+	if ( (*p) == 39u )
 		goto st113;
 	goto tr160;
 st113:
 	if ( ++p == pe )
 		goto _test_eof113;
 case 113:
-	if ( (*p) == 39 )
+	if ( (*p) == 39u )
 		goto st114;
 	goto tr160;
 st114:
 	if ( ++p == pe )
 		goto _test_eof114;
 case 114:
-	if ( (*p) == 39 )
+	if ( (*p) == 39u )
 		goto st115;
 	goto tr160;
 st115:
 	if ( ++p == pe )
 		goto _test_eof115;
 case 115:
-	if ( (*p) == 39 )
+	if ( (*p) == 39u )
 		goto tr164;
 	goto tr160;
-tr133:
+tr130:
 #line 1 "NONE"
 	{te = p+1;}
-#line 454 "wikitext_ragel.rl"
+#line 455 "ext/wikitext/wikitext_ragel.rl"
 	{act = 45;}
 	goto st116;
 st116:
 	if ( ++p == pe )
 		goto _test_eof116;
 case 116:
-#line 1105 "wikitext_ragel.c"
+#line 1063 "ext/wikitext/wikitext_ragel.c"
 	switch( (*p) ) {
-		case 43: goto st110;
-		case 45: goto tr133;
-		case 47: goto st110;
-		case 64: goto tr165;
-		case 92: goto st110;
-		case 94: goto st110;
-		case 95: goto tr133;
-		case 126: goto st110;
+		case 43u: goto st110;
+		case 45u: goto tr130;
+		case 47u: goto st110;
+		case 64u: goto tr165;
+		case 92u: goto st110;
+		case 94u: goto st110;
+		case 95u: goto tr130;
+		case 126u: goto st110;
 	}
-	if ( (*p) < 46 ) {
-		if ( 36 <= (*p) && (*p) <= 37 )
+	if ( (*p) < 46u ) {
+		if ( 36u <= (*p) && (*p) <= 37u )
 			goto st110;
-	} else if ( (*p) > 57 ) {
-		if ( (*p) > 90 ) {
-			if ( 97 <= (*p) && (*p) <= 122 )
-				goto st20;
-		} else if ( (*p) >= 65 )
-			goto st20;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto st14;
+		} else if ( (*p) >= 65u )
+			goto st14;
 	} else
-		goto st20;
+		goto st14;
 	goto tr155;
-st20:
+st14:
 	if ( ++p == pe )
-		goto _test_eof20;
-case 20:
+		goto _test_eof14;
+case 14:
 	switch( (*p) ) {
-		case 64: goto st21;
-		case 95: goto st20;
+		case 64u: goto st15;
+		case 95u: goto st14;
 	}
-	if ( (*p) < 48 ) {
-		if ( 45 <= (*p) && (*p) <= 46 )
-			goto st20;
-	} else if ( (*p) > 57 ) {
-		if ( (*p) > 90 ) {
-			if ( 97 <= (*p) && (*p) <= 122 )
-				goto st20;
-		} else if ( (*p) >= 65 )
-			goto st20;
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st14;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto st14;
+		} else if ( (*p) >= 65u )
+			goto st14;
 	} else
-		goto st20;
-	goto tr23;
-st21:
+		goto st14;
+	goto tr16;
+st15:
 	if ( ++p == pe )
-		goto _test_eof21;
-case 21:
-	if ( (*p) < 65 ) {
-		if ( 48 <= (*p) && (*p) <= 57 )
-			goto st22;
-	} else if ( (*p) > 90 ) {
-		if ( 97 <= (*p) && (*p) <= 122 )
-			goto st22;
+		goto _test_eof15;
+case 15:
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st16;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
+			goto st16;
 	} else
-		goto st22;
-	goto tr23;
-st22:
+		goto st16;
+	goto tr16;
+st16:
 	if ( ++p == pe )
-		goto _test_eof22;
-case 22:
-	if ( (*p) == 46 )
-		goto st23;
-	if ( (*p) < 65 ) {
-		if ( 48 <= (*p) && (*p) <= 57 )
-			goto st22;
-	} else if ( (*p) > 90 ) {
-		if ( 97 <= (*p) && (*p) <= 122 )
-			goto st22;
+		goto _test_eof16;
+case 16:
+	if ( (*p) == 46u )
+		goto st17;
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st16;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
+			goto st16;
 	} else
-		goto st22;
-	goto tr23;
-st23:
+		goto st16;
+	goto tr16;
+st17:
 	if ( ++p == pe )
-		goto _test_eof23;
-case 23:
-	if ( (*p) < 65 ) {
-		if ( 48 <= (*p) && (*p) <= 57 )
-			goto st22;
-	} else if ( (*p) > 90 ) {
-		if ( 97 <= (*p) && (*p) <= 122 )
-			goto st24;
+		goto _test_eof17;
+case 17:
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st16;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
+			goto st18;
 	} else
-		goto st24;
-	goto tr23;
-st24:
+		goto st18;
+	goto tr16;
+st18:
 	if ( ++p == pe )
-		goto _test_eof24;
-case 24:
-	if ( (*p) == 46 )
-		goto st23;
-	if ( (*p) < 65 ) {
-		if ( 48 <= (*p) && (*p) <= 57 )
-			goto st22;
-	} else if ( (*p) > 90 ) {
-		if ( 97 <= (*p) && (*p) <= 122 )
-			goto tr29;
+		goto _test_eof18;
+case 18:
+	if ( (*p) == 46u )
+		goto st17;
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st16;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
+			goto tr22;
 	} else
-		goto tr29;
-	goto tr23;
-tr29:
+		goto tr22;
+	goto tr16;
+tr22:
 #line 1 "NONE"
 	{te = p+1;}
-#line 303 "wikitext_ragel.rl"
+#line 304 "ext/wikitext/wikitext_ragel.rl"
 	{act = 22;}
 	goto st117;
 st117:
 	if ( ++p == pe )
 		goto _test_eof117;
 case 117:
-#line 1214 "wikitext_ragel.c"
-	if ( (*p) == 46 )
-		goto st23;
-	if ( (*p) < 65 ) {
-		if ( 48 <= (*p) && (*p) <= 57 )
-			goto st22;
-	} else if ( (*p) > 90 ) {
-		if ( 97 <= (*p) && (*p) <= 122 )
+#line 1172 "ext/wikitext/wikitext_ragel.c"
+	if ( (*p) == 46u )
+		goto st17;
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st16;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
 			goto tr167;
 	} else
 		goto tr167;
@@ -1225,21 +1183,21 @@ case 117:
 tr167:
 #line 1 "NONE"
 	{te = p+1;}
-#line 303 "wikitext_ragel.rl"
+#line 304 "ext/wikitext/wikitext_ragel.rl"
 	{act = 22;}
 	goto st118;
 st118:
 	if ( ++p == pe )
 		goto _test_eof118;
 case 118:
-#line 1236 "wikitext_ragel.c"
-	if ( (*p) == 46 )
-		goto st23;
-	if ( (*p) < 65 ) {
-		if ( 48 <= (*p) && (*p) <= 57 )
-			goto st22;
-	} else if ( (*p) > 90 ) {
-		if ( 97 <= (*p) && (*p) <= 122 )
+#line 1194 "ext/wikitext/wikitext_ragel.c"
+	if ( (*p) == 46u )
+		goto st17;
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st16;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
 			goto tr168;
 	} else
 		goto tr168;
@@ -1247,21 +1205,21 @@ case 118:
 tr168:
 #line 1 "NONE"
 	{te = p+1;}
-#line 303 "wikitext_ragel.rl"
+#line 304 "ext/wikitext/wikitext_ragel.rl"
 	{act = 22;}
 	goto st119;
 st119:
 	if ( ++p == pe )
 		goto _test_eof119;
 case 119:
-#line 1258 "wikitext_ragel.c"
-	if ( (*p) == 46 )
-		goto st23;
-	if ( (*p) < 65 ) {
-		if ( 48 <= (*p) && (*p) <= 57 )
-			goto st22;
-	} else if ( (*p) > 90 ) {
-		if ( 97 <= (*p) && (*p) <= 122 )
+#line 1216 "ext/wikitext/wikitext_ragel.c"
+	if ( (*p) == 46u )
+		goto st17;
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st16;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
 			goto tr169;
 	} else
 		goto tr169;
@@ -1269,91 +1227,91 @@ case 119:
 tr169:
 #line 1 "NONE"
 	{te = p+1;}
-#line 303 "wikitext_ragel.rl"
+#line 304 "ext/wikitext/wikitext_ragel.rl"
 	{act = 22;}
 	goto st120;
 st120:
 	if ( ++p == pe )
 		goto _test_eof120;
 case 120:
-#line 1280 "wikitext_ragel.c"
-	if ( (*p) == 46 )
-		goto st23;
-	if ( (*p) < 65 ) {
-		if ( 48 <= (*p) && (*p) <= 57 )
-			goto st22;
-	} else if ( (*p) > 90 ) {
-		if ( 97 <= (*p) && (*p) <= 122 )
-			goto st22;
+#line 1238 "ext/wikitext/wikitext_ragel.c"
+	if ( (*p) == 46u )
+		goto st17;
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st16;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
+			goto st16;
 	} else
-		goto st22;
+		goto st16;
 	goto tr166;
 tr165:
 #line 1 "NONE"
 	{te = p+1;}
-#line 454 "wikitext_ragel.rl"
+#line 455 "ext/wikitext/wikitext_ragel.rl"
 	{act = 45;}
 	goto st121;
 st121:
 	if ( ++p == pe )
 		goto _test_eof121;
 case 121:
-#line 1302 "wikitext_ragel.c"
+#line 1260 "ext/wikitext/wikitext_ragel.c"
 	switch( (*p) ) {
-		case 43: goto st110;
-		case 45: goto st110;
-		case 47: goto st110;
-		case 64: goto st110;
-		case 92: goto st110;
-		case 126: goto st110;
+		case 43u: goto st110;
+		case 45u: goto st110;
+		case 47u: goto st110;
+		case 64u: goto st110;
+		case 92u: goto st110;
+		case 126u: goto st110;
 	}
-	if ( (*p) < 65 ) {
-		if ( (*p) > 37 ) {
-			if ( 48 <= (*p) && (*p) <= 57 )
-				goto st22;
-		} else if ( (*p) >= 36 )
+	if ( (*p) < 65u ) {
+		if ( (*p) > 37u ) {
+			if ( 48u <= (*p) && (*p) <= 57u )
+				goto st16;
+		} else if ( (*p) >= 36u )
 			goto st110;
-	} else if ( (*p) > 90 ) {
-		if ( (*p) > 95 ) {
-			if ( 97 <= (*p) && (*p) <= 122 )
-				goto st22;
-		} else if ( (*p) >= 94 )
+	} else if ( (*p) > 90u ) {
+		if ( (*p) > 95u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto st16;
+		} else if ( (*p) >= 94u )
 			goto st110;
 	} else
-		goto st22;
+		goto st16;
 	goto tr155;
-tr134:
+tr131:
 #line 1 "NONE"
 	{te = p+1;}
-#line 436 "wikitext_ragel.rl"
+#line 437 "ext/wikitext/wikitext_ragel.rl"
 	{act = 43;}
 	goto st122;
 st122:
 	if ( ++p == pe )
 		goto _test_eof122;
 case 122:
-#line 1336 "wikitext_ragel.c"
+#line 1294 "ext/wikitext/wikitext_ragel.c"
 	switch( (*p) ) {
-		case 33: goto st109;
-		case 44: goto st109;
-		case 45: goto st20;
-		case 46: goto tr134;
-		case 63: goto st109;
-		case 64: goto st21;
-		case 95: goto st20;
+		case 33u: goto st109;
+		case 44u: goto st109;
+		case 45u: goto st14;
+		case 46u: goto tr131;
+		case 63u: goto st109;
+		case 64u: goto st15;
+		case 95u: goto st14;
 	}
-	if ( (*p) < 58 ) {
-		if ( (*p) > 41 ) {
-			if ( 48 <= (*p) && (*p) <= 57 )
-				goto st20;
-		} else if ( (*p) >= 40 )
+	if ( (*p) < 58u ) {
+		if ( (*p) > 41u ) {
+			if ( 48u <= (*p) && (*p) <= 57u )
+				goto st14;
+		} else if ( (*p) >= 40u )
 			goto st109;
-	} else if ( (*p) > 59 ) {
-		if ( (*p) > 90 ) {
-			if ( 97 <= (*p) && (*p) <= 122 )
-				goto st20;
-		} else if ( (*p) >= 65 )
-			goto st20;
+	} else if ( (*p) > 59u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto st14;
+		} else if ( (*p) >= 65u )
+			goto st14;
 	} else
 		goto st109;
 	goto tr154;
@@ -1362,23 +1320,23 @@ st123:
 		goto _test_eof123;
 case 123:
 	switch( (*p) ) {
-		case 43: goto st110;
-		case 45: goto st124;
-		case 47: goto st110;
-		case 64: goto st110;
-		case 92: goto st110;
-		case 94: goto st110;
-		case 95: goto st124;
-		case 126: goto st110;
+		case 43u: goto st110;
+		case 45u: goto st124;
+		case 47u: goto st110;
+		case 64u: goto st110;
+		case 92u: goto st110;
+		case 94u: goto st110;
+		case 95u: goto st124;
+		case 126u: goto st110;
 	}
-	if ( (*p) < 46 ) {
-		if ( 36 <= (*p) && (*p) <= 37 )
+	if ( (*p) < 46u ) {
+		if ( 36u <= (*p) && (*p) <= 37u )
 			goto st110;
-	} else if ( (*p) > 57 ) {
-		if ( (*p) > 90 ) {
-			if ( 97 <= (*p) && (*p) <= 122 )
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
 				goto st125;
-		} else if ( (*p) >= 65 )
+		} else if ( (*p) >= 65u )
 			goto st125;
 	} else
 		goto st125;
@@ -1388,23 +1346,23 @@ st124:
 		goto _test_eof124;
 case 124:
 	switch( (*p) ) {
-		case 43: goto st110;
-		case 45: goto st124;
-		case 47: goto st123;
-		case 64: goto st110;
-		case 92: goto st110;
-		case 94: goto st110;
-		case 95: goto st124;
-		case 126: goto st110;
+		case 43u: goto st110;
+		case 45u: goto st124;
+		case 47u: goto st123;
+		case 64u: goto st110;
+		case 92u: goto st110;
+		case 94u: goto st110;
+		case 95u: goto st124;
+		case 126u: goto st110;
 	}
-	if ( (*p) < 46 ) {
-		if ( 36 <= (*p) && (*p) <= 37 )
+	if ( (*p) < 46u ) {
+		if ( 36u <= (*p) && (*p) <= 37u )
 			goto st110;
-	} else if ( (*p) > 57 ) {
-		if ( (*p) > 90 ) {
-			if ( 97 <= (*p) && (*p) <= 122 )
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
 				goto st125;
-		} else if ( (*p) >= 65 )
+		} else if ( (*p) >= 65u )
 			goto st125;
 	} else
 		goto st125;
@@ -1414,14 +1372,14 @@ st125:
 		goto _test_eof125;
 case 125:
 	switch( (*p) ) {
-		case 47: goto st126;
-		case 95: goto st125;
+		case 47u: goto st126;
+		case 95u: goto st125;
 	}
-	if ( (*p) < 65 ) {
-		if ( 45 <= (*p) && (*p) <= 57 )
+	if ( (*p) < 65u ) {
+		if ( 45u <= (*p) && (*p) <= 57u )
 			goto st125;
-	} else if ( (*p) > 90 ) {
-		if ( 97 <= (*p) && (*p) <= 122 )
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
 			goto st125;
 	} else
 		goto st125;
@@ -1430,48 +1388,48 @@ st126:
 	if ( ++p == pe )
 		goto _test_eof126;
 case 126:
-	if ( (*p) == 95 )
+	if ( (*p) == 95u )
 		goto st125;
-	if ( (*p) < 48 ) {
-		if ( 45 <= (*p) && (*p) <= 46 )
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
 			goto st125;
-	} else if ( (*p) > 57 ) {
-		if ( (*p) > 90 ) {
-			if ( 97 <= (*p) && (*p) <= 122 )
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
 				goto st125;
-		} else if ( (*p) >= 65 )
+		} else if ( (*p) >= 65u )
 			goto st125;
 	} else
 		goto st125;
 	goto tr170;
-tr136:
+tr133:
 #line 1 "NONE"
 	{te = p+1;}
-#line 442 "wikitext_ragel.rl"
+#line 443 "ext/wikitext/wikitext_ragel.rl"
 	{act = 44;}
 	goto st127;
 st127:
 	if ( ++p == pe )
 		goto _test_eof127;
 case 127:
-#line 1458 "wikitext_ragel.c"
+#line 1416 "ext/wikitext/wikitext_ragel.c"
 	switch( (*p) ) {
-		case 64: goto st21;
-		case 95: goto st20;
+		case 64u: goto st15;
+		case 95u: goto st14;
 	}
-	if ( (*p) < 48 ) {
-		if ( 45 <= (*p) && (*p) <= 46 )
-			goto st20;
-	} else if ( (*p) > 57 ) {
-		if ( (*p) > 90 ) {
-			if ( 97 <= (*p) && (*p) <= 122 )
-				goto tr136;
-		} else if ( (*p) >= 65 )
-			goto tr136;
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st14;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto tr133;
+		} else if ( (*p) >= 65u )
+			goto tr133;
 	} else
-		goto tr136;
+		goto tr133;
 	goto tr174;
-tr137:
+tr134:
 #line 1 "NONE"
 	{te = p+1;}
 	goto st128;
@@ -1479,640 +1437,640 @@ st128:
 	if ( ++p == pe )
 		goto _test_eof128;
 case 128:
-#line 1483 "wikitext_ragel.c"
+#line 1441 "ext/wikitext/wikitext_ragel.c"
 	switch( (*p) ) {
-		case 47: goto st25;
-		case 66: goto st55;
-		case 69: goto st65;
-		case 78: goto st67;
-		case 80: goto st73;
-		case 83: goto st76;
-		case 84: goto st82;
-		case 98: goto st55;
-		case 101: goto st65;
-		case 110: goto st67;
-		case 112: goto st84;
-		case 115: goto st76;
-		case 116: goto st82;
+		case 47u: goto st19;
+		case 66u: goto st49;
+		case 69u: goto st59;
+		case 78u: goto st61;
+		case 80u: goto st67;
+		case 83u: goto st70;
+		case 84u: goto st76;
+		case 98u: goto st49;
+		case 101u: goto st59;
+		case 110u: goto st61;
+		case 112u: goto st78;
+		case 115u: goto st70;
+		case 116u: goto st76;
 	}
 	goto tr175;
+st19:
+	if ( ++p == pe )
+		goto _test_eof19;
+case 19:
+	switch( (*p) ) {
+		case 66u: goto st20;
+		case 69u: goto st30;
+		case 78u: goto st32;
+		case 80u: goto st38;
+		case 83u: goto st41;
+		case 84u: goto st47;
+		case 98u: goto st20;
+		case 101u: goto st30;
+		case 110u: goto st32;
+		case 112u: goto st38;
+		case 115u: goto st41;
+		case 116u: goto st47;
+	}
+	goto tr23;
+st20:
+	if ( ++p == pe )
+		goto _test_eof20;
+case 20:
+	switch( (*p) ) {
+		case 76u: goto st21;
+		case 108u: goto st21;
+	}
+	goto tr23;
+st21:
+	if ( ++p == pe )
+		goto _test_eof21;
+case 21:
+	switch( (*p) ) {
+		case 79u: goto st22;
+		case 111u: goto st22;
+	}
+	goto tr23;
+st22:
+	if ( ++p == pe )
+		goto _test_eof22;
+case 22:
+	switch( (*p) ) {
+		case 67u: goto st23;
+		case 99u: goto st23;
+	}
+	goto tr23;
+st23:
+	if ( ++p == pe )
+		goto _test_eof23;
+case 23:
+	switch( (*p) ) {
+		case 75u: goto st24;
+		case 107u: goto st24;
+	}
+	goto tr23;
+st24:
+	if ( ++p == pe )
+		goto _test_eof24;
+case 24:
+	switch( (*p) ) {
+		case 81u: goto st25;
+		case 113u: goto st25;
+	}
+	goto tr23;
 st25:
 	if ( ++p == pe )
 		goto _test_eof25;
 case 25:
 	switch( (*p) ) {
-		case 66: goto st26;
-		case 69: goto st36;
-		case 78: goto st38;
-		case 80: goto st44;
-		case 83: goto st47;
-		case 84: goto st53;
-		case 98: goto st26;
-		case 101: goto st36;
-		case 110: goto st38;
-		case 112: goto st44;
-		case 115: goto st47;
-		case 116: goto st53;
+		case 85u: goto st26;
+		case 117u: goto st26;
 	}
-	goto tr30;
+	goto tr23;
 st26:
 	if ( ++p == pe )
 		goto _test_eof26;
 case 26:
 	switch( (*p) ) {
-		case 76: goto st27;
-		case 108: goto st27;
+		case 79u: goto st27;
+		case 111u: goto st27;
 	}
-	goto tr30;
+	goto tr23;
 st27:
 	if ( ++p == pe )
 		goto _test_eof27;
 case 27:
 	switch( (*p) ) {
-		case 79: goto st28;
-		case 111: goto st28;
+		case 84u: goto st28;
+		case 116u: goto st28;
 	}
-	goto tr30;
+	goto tr23;
 st28:
 	if ( ++p == pe )
 		goto _test_eof28;
 case 28:
 	switch( (*p) ) {
-		case 67: goto st29;
-		case 99: goto st29;
+		case 69u: goto st29;
+		case 101u: goto st29;
 	}
-	goto tr30;
+	goto tr23;
 st29:
 	if ( ++p == pe )
 		goto _test_eof29;
 case 29:
-	switch( (*p) ) {
-		case 75: goto st30;
-		case 107: goto st30;
-	}
-	goto tr30;
+	if ( (*p) == 62u )
+		goto tr39;
+	goto tr23;
 st30:
 	if ( ++p == pe )
 		goto _test_eof30;
 case 30:
 	switch( (*p) ) {
-		case 81: goto st31;
-		case 113: goto st31;
+		case 77u: goto st31;
+		case 109u: goto st31;
 	}
-	goto tr30;
+	goto tr23;
 st31:
 	if ( ++p == pe )
 		goto _test_eof31;
 case 31:
-	switch( (*p) ) {
-		case 85: goto st32;
-		case 117: goto st32;
-	}
-	goto tr30;
+	if ( (*p) == 62u )
+		goto tr41;
+	goto tr23;
 st32:
 	if ( ++p == pe )
 		goto _test_eof32;
 case 32:
 	switch( (*p) ) {
-		case 79: goto st33;
-		case 111: goto st33;
+		case 79u: goto st33;
+		case 111u: goto st33;
 	}
-	goto tr30;
+	goto tr23;
 st33:
 	if ( ++p == pe )
 		goto _test_eof33;
 case 33:
 	switch( (*p) ) {
-		case 84: goto st34;
-		case 116: goto st34;
+		case 87u: goto st34;
+		case 119u: goto st34;
 	}
-	goto tr30;
+	goto tr23;
 st34:
 	if ( ++p == pe )
 		goto _test_eof34;
 case 34:
 	switch( (*p) ) {
-		case 69: goto st35;
-		case 101: goto st35;
+		case 73u: goto st35;
+		case 105u: goto st35;
 	}
-	goto tr30;
+	goto tr23;
 st35:
 	if ( ++p == pe )
 		goto _test_eof35;
 case 35:
-	if ( (*p) == 62 )
-		goto tr46;
-	goto tr30;
+	switch( (*p) ) {
+		case 75u: goto st36;
+		case 107u: goto st36;
+	}
+	goto tr23;
 st36:
 	if ( ++p == pe )
 		goto _test_eof36;
 case 36:
 	switch( (*p) ) {
-		case 77: goto st37;
-		case 109: goto st37;
+		case 73u: goto st37;
+		case 105u: goto st37;
 	}
-	goto tr30;
+	goto tr23;
 st37:
 	if ( ++p == pe )
 		goto _test_eof37;
 case 37:
-	if ( (*p) == 62 )
-		goto tr48;
-	goto tr30;
+	if ( (*p) == 62u )
+		goto tr47;
+	goto tr23;
 st38:
 	if ( ++p == pe )
 		goto _test_eof38;
 case 38:
 	switch( (*p) ) {
-		case 79: goto st39;
-		case 111: goto st39;
+		case 82u: goto st39;
+		case 114u: goto st39;
 	}
-	goto tr30;
+	goto tr23;
 st39:
 	if ( ++p == pe )
 		goto _test_eof39;
 case 39:
 	switch( (*p) ) {
-		case 87: goto st40;
-		case 119: goto st40;
+		case 69u: goto st40;
+		case 101u: goto st40;
 	}
-	goto tr30;
+	goto tr23;
 st40:
 	if ( ++p == pe )
 		goto _test_eof40;
 case 40:
-	switch( (*p) ) {
-		case 73: goto st41;
-		case 105: goto st41;
-	}
-	goto tr30;
+	if ( (*p) == 62u )
+		goto tr50;
+	goto tr23;
 st41:
 	if ( ++p == pe )
 		goto _test_eof41;
 case 41:
 	switch( (*p) ) {
-		case 75: goto st42;
-		case 107: goto st42;
+		case 84u: goto st42;
+		case 116u: goto st42;
 	}
-	goto tr30;
+	goto tr23;
 st42:
 	if ( ++p == pe )
 		goto _test_eof42;
 case 42:
 	switch( (*p) ) {
-		case 73: goto st43;
-		case 105: goto st43;
+		case 82u: goto st43;
+		case 114u: goto st43;
 	}
-	goto tr30;
+	goto tr23;
 st43:
 	if ( ++p == pe )
 		goto _test_eof43;
 case 43:
-	if ( (*p) == 62 )
-		goto tr54;
-	goto tr30;
+	switch( (*p) ) {
+		case 79u: goto st44;
+		case 111u: goto st44;
+	}
+	goto tr23;
 st44:
 	if ( ++p == pe )
 		goto _test_eof44;
 case 44:
 	switch( (*p) ) {
-		case 82: goto st45;
-		case 114: goto st45;
+		case 78u: goto st45;
+		case 110u: goto st45;
 	}
-	goto tr30;
+	goto tr23;
 st45:
 	if ( ++p == pe )
 		goto _test_eof45;
 case 45:
 	switch( (*p) ) {
-		case 69: goto st46;
-		case 101: goto st46;
+		case 71u: goto st46;
+		case 103u: goto st46;
 	}
-	goto tr30;
+	goto tr23;
 st46:
 	if ( ++p == pe )
 		goto _test_eof46;
 case 46:
-	if ( (*p) == 62 )
-		goto tr57;
-	goto tr30;
+	if ( (*p) == 62u )
+		goto tr56;
+	goto tr23;
 st47:
 	if ( ++p == pe )
 		goto _test_eof47;
 case 47:
 	switch( (*p) ) {
-		case 84: goto st48;
-		case 116: goto st48;
+		case 84u: goto st48;
+		case 116u: goto st48;
 	}
-	goto tr30;
+	goto tr23;
 st48:
 	if ( ++p == pe )
 		goto _test_eof48;
 case 48:
-	switch( (*p) ) {
-		case 82: goto st49;
-		case 114: goto st49;
-	}
-	goto tr30;
+	if ( (*p) == 62u )
+		goto tr58;
+	goto tr23;
 st49:
 	if ( ++p == pe )
 		goto _test_eof49;
 case 49:
 	switch( (*p) ) {
-		case 79: goto st50;
-		case 111: goto st50;
+		case 76u: goto st50;
+		case 108u: goto st50;
 	}
-	goto tr30;
+	goto tr23;
 st50:
 	if ( ++p == pe )
 		goto _test_eof50;
 case 50:
 	switch( (*p) ) {
-		case 78: goto st51;
-		case 110: goto st51;
+		case 79u: goto st51;
+		case 111u: goto st51;
 	}
-	goto tr30;
+	goto tr23;
 st51:
 	if ( ++p == pe )
 		goto _test_eof51;
 case 51:
 	switch( (*p) ) {
-		case 71: goto st52;
-		case 103: goto st52;
+		case 67u: goto st52;
+		case 99u: goto st52;
 	}
-	goto tr30;
+	goto tr23;
 st52:
 	if ( ++p == pe )
 		goto _test_eof52;
 case 52:
-	if ( (*p) == 62 )
-		goto tr63;
-	goto tr30;
+	switch( (*p) ) {
+		case 75u: goto st53;
+		case 107u: goto st53;
+	}
+	goto tr23;
 st53:
 	if ( ++p == pe )
 		goto _test_eof53;
 case 53:
 	switch( (*p) ) {
-		case 84: goto st54;
-		case 116: goto st54;
+		case 81u: goto st54;
+		case 113u: goto st54;
 	}
-	goto tr30;
+	goto tr23;
 st54:
 	if ( ++p == pe )
 		goto _test_eof54;
 case 54:
-	if ( (*p) == 62 )
-		goto tr65;
-	goto tr30;
+	switch( (*p) ) {
+		case 85u: goto st55;
+		case 117u: goto st55;
+	}
+	goto tr23;
 st55:
 	if ( ++p == pe )
 		goto _test_eof55;
 case 55:
 	switch( (*p) ) {
-		case 76: goto st56;
-		case 108: goto st56;
+		case 79u: goto st56;
+		case 111u: goto st56;
 	}
-	goto tr30;
+	goto tr23;
 st56:
 	if ( ++p == pe )
 		goto _test_eof56;
 case 56:
 	switch( (*p) ) {
-		case 79: goto st57;
-		case 111: goto st57;
+		case 84u: goto st57;
+		case 116u: goto st57;
 	}
-	goto tr30;
+	goto tr23;
 st57:
 	if ( ++p == pe )
 		goto _test_eof57;
 case 57:
 	switch( (*p) ) {
-		case 67: goto st58;
-		case 99: goto st58;
+		case 69u: goto st58;
+		case 101u: goto st58;
 	}
-	goto tr30;
+	goto tr23;
 st58:
 	if ( ++p == pe )
 		goto _test_eof58;
 case 58:
-	switch( (*p) ) {
-		case 75: goto st59;
-		case 107: goto st59;
-	}
-	goto tr30;
+	if ( (*p) == 62u )
+		goto tr68;
+	goto tr23;
 st59:
 	if ( ++p == pe )
 		goto _test_eof59;
 case 59:
 	switch( (*p) ) {
-		case 81: goto st60;
-		case 113: goto st60;
+		case 77u: goto st60;
+		case 109u: goto st60;
 	}
-	goto tr30;
+	goto tr23;
 st60:
 	if ( ++p == pe )
 		goto _test_eof60;
 case 60:
-	switch( (*p) ) {
-		case 85: goto st61;
-		case 117: goto st61;
-	}
-	goto tr30;
+	if ( (*p) == 62u )
+		goto tr70;
+	goto tr23;
 st61:
 	if ( ++p == pe )
 		goto _test_eof61;
 case 61:
 	switch( (*p) ) {
-		case 79: goto st62;
-		case 111: goto st62;
+		case 79u: goto st62;
+		case 111u: goto st62;
 	}
-	goto tr30;
+	goto tr23;
 st62:
 	if ( ++p == pe )
 		goto _test_eof62;
 case 62:
 	switch( (*p) ) {
-		case 84: goto st63;
-		case 116: goto st63;
+		case 87u: goto st63;
+		case 119u: goto st63;
 	}
-	goto tr30;
+	goto tr23;
 st63:
 	if ( ++p == pe )
 		goto _test_eof63;
 case 63:
 	switch( (*p) ) {
-		case 69: goto st64;
-		case 101: goto st64;
+		case 73u: goto st64;
+		case 105u: goto st64;
 	}
-	goto tr30;
+	goto tr23;
 st64:
 	if ( ++p == pe )
 		goto _test_eof64;
 case 64:
-	if ( (*p) == 62 )
-		goto tr75;
-	goto tr30;
+	switch( (*p) ) {
+		case 75u: goto st65;
+		case 107u: goto st65;
+	}
+	goto tr23;
 st65:
 	if ( ++p == pe )
 		goto _test_eof65;
 case 65:
 	switch( (*p) ) {
-		case 77: goto st66;
-		case 109: goto st66;
+		case 73u: goto st66;
+		case 105u: goto st66;
 	}
-	goto tr30;
+	goto tr23;
 st66:
 	if ( ++p == pe )
 		goto _test_eof66;
 case 66:
-	if ( (*p) == 62 )
-		goto tr77;
-	goto tr30;
+	if ( (*p) == 62u )
+		goto tr76;
+	goto tr23;
 st67:
 	if ( ++p == pe )
 		goto _test_eof67;
 case 67:
 	switch( (*p) ) {
-		case 79: goto st68;
-		case 111: goto st68;
+		case 82u: goto st68;
+		case 114u: goto st68;
 	}
-	goto tr30;
+	goto tr23;
 st68:
 	if ( ++p == pe )
 		goto _test_eof68;
 case 68:
 	switch( (*p) ) {
-		case 87: goto st69;
-		case 119: goto st69;
+		case 69u: goto st69;
+		case 101u: goto st69;
 	}
-	goto tr30;
+	goto tr23;
 st69:
 	if ( ++p == pe )
 		goto _test_eof69;
 case 69:
-	switch( (*p) ) {
-		case 73: goto st70;
-		case 105: goto st70;
-	}
-	goto tr30;
+	if ( (*p) == 62u )
+		goto tr79;
+	goto tr23;
 st70:
 	if ( ++p == pe )
 		goto _test_eof70;
 case 70:
 	switch( (*p) ) {
-		case 75: goto st71;
-		case 107: goto st71;
+		case 84u: goto st71;
+		case 116u: goto st71;
 	}
-	goto tr30;
+	goto tr23;
 st71:
 	if ( ++p == pe )
 		goto _test_eof71;
 case 71:
 	switch( (*p) ) {
-		case 73: goto st72;
-		case 105: goto st72;
+		case 82u: goto st72;
+		case 114u: goto st72;
 	}
-	goto tr30;
+	goto tr23;
 st72:
 	if ( ++p == pe )
 		goto _test_eof72;
 case 72:
-	if ( (*p) == 62 )
-		goto tr83;
-	goto tr30;
+	switch( (*p) ) {
+		case 79u: goto st73;
+		case 111u: goto st73;
+	}
+	goto tr23;
 st73:
 	if ( ++p == pe )
 		goto _test_eof73;
 case 73:
 	switch( (*p) ) {
-		case 82: goto st74;
-		case 114: goto st74;
+		case 78u: goto st74;
+		case 110u: goto st74;
 	}
-	goto tr30;
+	goto tr23;
 st74:
 	if ( ++p == pe )
 		goto _test_eof74;
 case 74:
 	switch( (*p) ) {
-		case 69: goto st75;
-		case 101: goto st75;
+		case 71u: goto st75;
+		case 103u: goto st75;
 	}
-	goto tr30;
+	goto tr23;
 st75:
 	if ( ++p == pe )
 		goto _test_eof75;
 case 75:
-	if ( (*p) == 62 )
-		goto tr86;
-	goto tr30;
+	if ( (*p) == 62u )
+		goto tr85;
+	goto tr23;
 st76:
 	if ( ++p == pe )
 		goto _test_eof76;
 case 76:
 	switch( (*p) ) {
-		case 84: goto st77;
-		case 116: goto st77;
+		case 84u: goto st77;
+		case 116u: goto st77;
 	}
-	goto tr30;
+	goto tr23;
 st77:
 	if ( ++p == pe )
 		goto _test_eof77;
 case 77:
-	switch( (*p) ) {
-		case 82: goto st78;
-		case 114: goto st78;
-	}
-	goto tr30;
+	if ( (*p) == 62u )
+		goto tr87;
+	goto tr23;
 st78:
 	if ( ++p == pe )
 		goto _test_eof78;
 case 78:
 	switch( (*p) ) {
-		case 79: goto st79;
-		case 111: goto st79;
+		case 82u: goto st68;
+		case 114u: goto st79;
 	}
-	goto tr30;
+	goto tr23;
 st79:
 	if ( ++p == pe )
 		goto _test_eof79;
 case 79:
 	switch( (*p) ) {
-		case 78: goto st80;
-		case 110: goto st80;
+		case 69u: goto st69;
+		case 101u: goto st80;
 	}
-	goto tr30;
+	goto tr23;
 st80:
 	if ( ++p == pe )
 		goto _test_eof80;
 case 80:
 	switch( (*p) ) {
-		case 71: goto st81;
-		case 103: goto st81;
+		case 32u: goto st81;
+		case 62u: goto tr79;
 	}
-	goto tr30;
+	goto tr23;
 st81:
 	if ( ++p == pe )
 		goto _test_eof81;
 case 81:
-	if ( (*p) == 62 )
-		goto tr92;
-	goto tr30;
+	if ( (*p) == 108u )
+		goto st82;
+	goto tr23;
 st82:
 	if ( ++p == pe )
 		goto _test_eof82;
 case 82:
-	switch( (*p) ) {
-		case 84: goto st83;
-		case 116: goto st83;
-	}
-	goto tr30;
+	if ( (*p) == 97u )
+		goto st83;
+	goto tr23;
 st83:
 	if ( ++p == pe )
 		goto _test_eof83;
 case 83:
-	if ( (*p) == 62 )
-		goto tr94;
-	goto tr30;
+	if ( (*p) == 110u )
+		goto st84;
+	goto tr23;
 st84:
 	if ( ++p == pe )
 		goto _test_eof84;
 case 84:
-	switch( (*p) ) {
-		case 82: goto st74;
-		case 114: goto st85;
-	}
-	goto tr30;
+	if ( (*p) == 103u )
+		goto st85;
+	goto tr23;
 st85:
 	if ( ++p == pe )
 		goto _test_eof85;
 case 85:
-	switch( (*p) ) {
-		case 69: goto st75;
-		case 101: goto st86;
-	}
-	goto tr30;
+	if ( (*p) == 61u )
+		goto st86;
+	goto tr23;
 st86:
 	if ( ++p == pe )
 		goto _test_eof86;
 case 86:
-	switch( (*p) ) {
-		case 32: goto st87;
-		case 62: goto tr86;
-	}
-	goto tr30;
+	if ( (*p) == 34u )
+		goto st87;
+	goto tr23;
 st87:
 	if ( ++p == pe )
 		goto _test_eof87;
 case 87:
-	if ( (*p) == 108 )
+	if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
+			goto st88;
+	} else if ( (*p) >= 65u )
 		goto st88;
-	goto tr30;
+	goto tr23;
 st88:
 	if ( ++p == pe )
 		goto _test_eof88;
 case 88:
-	if ( (*p) == 97 )
+	if ( (*p) == 34u )
 		goto st89;
-	goto tr30;
+	if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
+			goto st88;
+	} else if ( (*p) >= 65u )
+		goto st88;
+	goto tr23;
 st89:
 	if ( ++p == pe )
 		goto _test_eof89;
 case 89:
-	if ( (*p) == 110 )
-		goto st90;
-	goto tr30;
-st90:
-	if ( ++p == pe )
-		goto _test_eof90;
-case 90:
-	if ( (*p) == 103 )
-		goto st91;
-	goto tr30;
-st91:
-	if ( ++p == pe )
-		goto _test_eof91;
-case 91:
-	if ( (*p) == 61 )
-		goto st92;
-	goto tr30;
-st92:
-	if ( ++p == pe )
-		goto _test_eof92;
-case 92:
-	if ( (*p) == 34 )
-		goto st93;
-	goto tr30;
-st93:
-	if ( ++p == pe )
-		goto _test_eof93;
-case 93:
-	if ( (*p) > 90 ) {
-		if ( 97 <= (*p) && (*p) <= 122 )
-			goto st94;
-	} else if ( (*p) >= 65 )
-		goto st94;
-	goto tr30;
-st94:
-	if ( ++p == pe )
-		goto _test_eof94;
-case 94:
-	if ( (*p) == 34 )
-		goto st95;
-	if ( (*p) > 90 ) {
-		if ( 97 <= (*p) && (*p) <= 122 )
-			goto st94;
-	} else if ( (*p) >= 65 )
-		goto st94;
-	goto tr30;
-st95:
-	if ( ++p == pe )
-		goto _test_eof95;
-case 95:
-	if ( (*p) == 62 )
-		goto tr106;
-	goto tr30;
-tr138:
-#line 45 "wikitext_ragel.rl"
+	if ( (*p) == 62u )
+		goto tr99;
+	goto tr23;
+tr135:
+#line 46 "ext/wikitext/wikitext_ragel.rl"
 	{
         MARK();
     }
@@ -2121,21 +2079,21 @@ st129:
 	if ( ++p == pe )
 		goto _test_eof129;
 case 129:
-#line 2125 "wikitext_ragel.c"
+#line 2083 "ext/wikitext/wikitext_ragel.c"
 	switch( (*p) ) {
-		case 32: goto st130;
-		case 61: goto tr138;
+		case 32u: goto st130;
+		case 61u: goto tr135;
 	}
 	goto tr184;
 st130:
 	if ( ++p == pe )
 		goto _test_eof130;
 case 130:
-	if ( (*p) == 32 )
+	if ( (*p) == 32u )
 		goto st130;
 	goto tr184;
-tr139:
-#line 45 "wikitext_ragel.rl"
+tr136:
+#line 46 "ext/wikitext/wikitext_ragel.rl"
 	{
         MARK();
     }
@@ -2144,136 +2102,136 @@ st131:
 	if ( ++p == pe )
 		goto _test_eof131;
 case 131:
-#line 2148 "wikitext_ragel.c"
-	if ( (*p) == 32 )
+#line 2106 "ext/wikitext/wikitext_ragel.c"
+	if ( (*p) == 32u )
 		goto tr187;
 	goto tr186;
-tr140:
+tr137:
 #line 1 "NONE"
 	{te = p+1;}
-#line 442 "wikitext_ragel.rl"
+#line 443 "ext/wikitext/wikitext_ragel.rl"
 	{act = 44;}
 	goto st132;
 st132:
 	if ( ++p == pe )
 		goto _test_eof132;
 case 132:
-#line 2162 "wikitext_ragel.c"
+#line 2120 "ext/wikitext/wikitext_ragel.c"
 	switch( (*p) ) {
-		case 64: goto st21;
-		case 84: goto tr188;
-		case 95: goto st20;
-		case 116: goto tr188;
+		case 64u: goto st15;
+		case 84u: goto tr188;
+		case 95u: goto st14;
+		case 116u: goto tr188;
 	}
-	if ( (*p) < 48 ) {
-		if ( 45 <= (*p) && (*p) <= 46 )
-			goto st20;
-	} else if ( (*p) > 57 ) {
-		if ( (*p) > 90 ) {
-			if ( 97 <= (*p) && (*p) <= 122 )
-				goto tr136;
-		} else if ( (*p) >= 65 )
-			goto tr136;
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st14;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto tr133;
+		} else if ( (*p) >= 65u )
+			goto tr133;
 	} else
-		goto tr136;
+		goto tr133;
 	goto tr174;
 tr188:
 #line 1 "NONE"
 	{te = p+1;}
-#line 442 "wikitext_ragel.rl"
+#line 443 "ext/wikitext/wikitext_ragel.rl"
 	{act = 44;}
 	goto st133;
 st133:
 	if ( ++p == pe )
 		goto _test_eof133;
 case 133:
-#line 2191 "wikitext_ragel.c"
+#line 2149 "ext/wikitext/wikitext_ragel.c"
 	switch( (*p) ) {
-		case 64: goto st21;
-		case 80: goto tr189;
-		case 95: goto st20;
-		case 112: goto tr189;
+		case 64u: goto st15;
+		case 80u: goto tr189;
+		case 95u: goto st14;
+		case 112u: goto tr189;
 	}
-	if ( (*p) < 48 ) {
-		if ( 45 <= (*p) && (*p) <= 46 )
-			goto st20;
-	} else if ( (*p) > 57 ) {
-		if ( (*p) > 90 ) {
-			if ( 97 <= (*p) && (*p) <= 122 )
-				goto tr136;
-		} else if ( (*p) >= 65 )
-			goto tr136;
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st14;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto tr133;
+		} else if ( (*p) >= 65u )
+			goto tr133;
 	} else
-		goto tr136;
+		goto tr133;
 	goto tr174;
 tr189:
 #line 1 "NONE"
 	{te = p+1;}
-#line 442 "wikitext_ragel.rl"
+#line 443 "ext/wikitext/wikitext_ragel.rl"
 	{act = 44;}
 	goto st134;
 st134:
 	if ( ++p == pe )
 		goto _test_eof134;
 case 134:
-#line 2220 "wikitext_ragel.c"
+#line 2178 "ext/wikitext/wikitext_ragel.c"
 	switch( (*p) ) {
-		case 58: goto st96;
-		case 64: goto st21;
-		case 95: goto st20;
+		case 58u: goto st90;
+		case 64u: goto st15;
+		case 95u: goto st14;
 	}
-	if ( (*p) < 48 ) {
-		if ( 45 <= (*p) && (*p) <= 46 )
-			goto st20;
-	} else if ( (*p) > 57 ) {
-		if ( (*p) > 90 ) {
-			if ( 97 <= (*p) && (*p) <= 122 )
-				goto tr136;
-		} else if ( (*p) >= 65 )
-			goto tr136;
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st14;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto tr133;
+		} else if ( (*p) >= 65u )
+			goto tr133;
 	} else
-		goto tr136;
+		goto tr133;
 	goto tr174;
-st96:
+st90:
 	if ( ++p == pe )
-		goto _test_eof96;
-case 96:
-	if ( (*p) == 47 )
-		goto st97;
-	goto tr107;
-st97:
+		goto _test_eof90;
+case 90:
+	if ( (*p) == 47u )
+		goto st91;
+	goto tr100;
+st91:
 	if ( ++p == pe )
-		goto _test_eof97;
-case 97:
-	if ( (*p) == 47 )
-		goto st98;
-	goto tr107;
-st98:
+		goto _test_eof91;
+case 91:
+	if ( (*p) == 47u )
+		goto st92;
+	goto tr100;
+st92:
 	if ( ++p == pe )
-		goto _test_eof98;
-case 98:
+		goto _test_eof92;
+case 92:
 	switch( (*p) ) {
-		case 45: goto tr110;
-		case 61: goto tr110;
-		case 95: goto tr110;
-		case 126: goto tr110;
+		case 45u: goto tr103;
+		case 61u: goto tr103;
+		case 95u: goto tr103;
+		case 126u: goto tr103;
 	}
-	if ( (*p) < 47 ) {
-		if ( (*p) > 40 ) {
-			if ( 42 <= (*p) && (*p) <= 43 )
-				goto tr110;
-		} else if ( (*p) >= 35 )
-			goto tr110;
-	} else if ( (*p) > 57 ) {
-		if ( (*p) > 90 ) {
-			if ( 97 <= (*p) && (*p) <= 122 )
-				goto tr110;
-		} else if ( (*p) >= 64 )
-			goto tr110;
+	if ( (*p) < 47u ) {
+		if ( (*p) > 40u ) {
+			if ( 42u <= (*p) && (*p) <= 43u )
+				goto tr103;
+		} else if ( (*p) >= 35u )
+			goto tr103;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto tr103;
+		} else if ( (*p) >= 64u )
+			goto tr103;
 	} else
-		goto tr110;
-	goto tr107;
-tr110:
+		goto tr103;
+	goto tr100;
+tr103:
 #line 1 "NONE"
 	{te = p+1;}
 	goto st135;
@@ -2281,457 +2239,457 @@ st135:
 	if ( ++p == pe )
 		goto _test_eof135;
 case 135:
-#line 2285 "wikitext_ragel.c"
+#line 2243 "ext/wikitext/wikitext_ragel.c"
 	switch( (*p) ) {
-		case 33: goto st99;
-		case 41: goto st99;
-		case 44: goto st99;
-		case 46: goto st99;
-		case 61: goto tr110;
-		case 63: goto st99;
-		case 95: goto tr110;
-		case 126: goto tr110;
+		case 33u: goto st93;
+		case 41u: goto st93;
+		case 44u: goto st93;
+		case 46u: goto st93;
+		case 61u: goto tr103;
+		case 63u: goto st93;
+		case 95u: goto tr103;
+		case 126u: goto tr103;
 	}
-	if ( (*p) < 58 ) {
-		if ( 35 <= (*p) && (*p) <= 57 )
-			goto tr110;
-	} else if ( (*p) > 59 ) {
-		if ( (*p) > 90 ) {
-			if ( 97 <= (*p) && (*p) <= 122 )
-				goto tr110;
-		} else if ( (*p) >= 64 )
-			goto tr110;
+	if ( (*p) < 58u ) {
+		if ( 35u <= (*p) && (*p) <= 57u )
+			goto tr103;
+	} else if ( (*p) > 59u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto tr103;
+		} else if ( (*p) >= 64u )
+			goto tr103;
 	} else
-		goto st99;
+		goto st93;
 	goto tr191;
-st99:
+st93:
 	if ( ++p == pe )
-		goto _test_eof99;
-case 99:
+		goto _test_eof93;
+case 93:
 	switch( (*p) ) {
-		case 33: goto st99;
-		case 41: goto st99;
-		case 44: goto st99;
-		case 46: goto st99;
-		case 61: goto tr110;
-		case 63: goto st99;
-		case 95: goto tr110;
-		case 126: goto tr110;
+		case 33u: goto st93;
+		case 41u: goto st93;
+		case 44u: goto st93;
+		case 46u: goto st93;
+		case 61u: goto tr103;
+		case 63u: goto st93;
+		case 95u: goto tr103;
+		case 126u: goto tr103;
 	}
-	if ( (*p) < 58 ) {
-		if ( 35 <= (*p) && (*p) <= 57 )
-			goto tr110;
-	} else if ( (*p) > 59 ) {
-		if ( (*p) > 90 ) {
-			if ( 97 <= (*p) && (*p) <= 122 )
-				goto tr110;
-		} else if ( (*p) >= 64 )
-			goto tr110;
+	if ( (*p) < 58u ) {
+		if ( 35u <= (*p) && (*p) <= 57u )
+			goto tr103;
+	} else if ( (*p) > 59u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto tr103;
+		} else if ( (*p) >= 64u )
+			goto tr103;
 	} else
-		goto st99;
-	goto tr111;
-tr141:
+		goto st93;
+	goto tr104;
+tr138:
 #line 1 "NONE"
 	{te = p+1;}
-#line 442 "wikitext_ragel.rl"
+#line 443 "ext/wikitext/wikitext_ragel.rl"
 	{act = 44;}
 	goto st136;
 st136:
 	if ( ++p == pe )
 		goto _test_eof136;
 case 136:
-#line 2344 "wikitext_ragel.c"
+#line 2302 "ext/wikitext/wikitext_ragel.c"
 	switch( (*p) ) {
-		case 64: goto st21;
-		case 84: goto tr192;
-		case 95: goto st20;
-		case 116: goto tr192;
+		case 64u: goto st15;
+		case 84u: goto tr192;
+		case 95u: goto st14;
+		case 116u: goto tr192;
 	}
-	if ( (*p) < 48 ) {
-		if ( 45 <= (*p) && (*p) <= 46 )
-			goto st20;
-	} else if ( (*p) > 57 ) {
-		if ( (*p) > 90 ) {
-			if ( 97 <= (*p) && (*p) <= 122 )
-				goto tr136;
-		} else if ( (*p) >= 65 )
-			goto tr136;
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st14;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto tr133;
+		} else if ( (*p) >= 65u )
+			goto tr133;
 	} else
-		goto tr136;
+		goto tr133;
 	goto tr174;
 tr192:
 #line 1 "NONE"
 	{te = p+1;}
-#line 442 "wikitext_ragel.rl"
+#line 443 "ext/wikitext/wikitext_ragel.rl"
 	{act = 44;}
 	goto st137;
 st137:
 	if ( ++p == pe )
 		goto _test_eof137;
 case 137:
-#line 2373 "wikitext_ragel.c"
+#line 2331 "ext/wikitext/wikitext_ragel.c"
 	switch( (*p) ) {
-		case 64: goto st21;
-		case 84: goto tr193;
-		case 95: goto st20;
-		case 116: goto tr193;
+		case 64u: goto st15;
+		case 84u: goto tr193;
+		case 95u: goto st14;
+		case 116u: goto tr193;
 	}
-	if ( (*p) < 48 ) {
-		if ( 45 <= (*p) && (*p) <= 46 )
-			goto st20;
-	} else if ( (*p) > 57 ) {
-		if ( (*p) > 90 ) {
-			if ( 97 <= (*p) && (*p) <= 122 )
-				goto tr136;
-		} else if ( (*p) >= 65 )
-			goto tr136;
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st14;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto tr133;
+		} else if ( (*p) >= 65u )
+			goto tr133;
 	} else
-		goto tr136;
+		goto tr133;
 	goto tr174;
 tr193:
 #line 1 "NONE"
 	{te = p+1;}
-#line 442 "wikitext_ragel.rl"
+#line 443 "ext/wikitext/wikitext_ragel.rl"
 	{act = 44;}
 	goto st138;
 st138:
 	if ( ++p == pe )
 		goto _test_eof138;
 case 138:
-#line 2402 "wikitext_ragel.c"
+#line 2360 "ext/wikitext/wikitext_ragel.c"
 	switch( (*p) ) {
-		case 64: goto st21;
-		case 80: goto tr194;
-		case 95: goto st20;
-		case 112: goto tr194;
+		case 64u: goto st15;
+		case 80u: goto tr194;
+		case 95u: goto st14;
+		case 112u: goto tr194;
 	}
-	if ( (*p) < 48 ) {
-		if ( 45 <= (*p) && (*p) <= 46 )
-			goto st20;
-	} else if ( (*p) > 57 ) {
-		if ( (*p) > 90 ) {
-			if ( 97 <= (*p) && (*p) <= 122 )
-				goto tr136;
-		} else if ( (*p) >= 65 )
-			goto tr136;
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st14;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto tr133;
+		} else if ( (*p) >= 65u )
+			goto tr133;
 	} else
-		goto tr136;
+		goto tr133;
 	goto tr174;
 tr194:
 #line 1 "NONE"
 	{te = p+1;}
-#line 442 "wikitext_ragel.rl"
+#line 443 "ext/wikitext/wikitext_ragel.rl"
 	{act = 44;}
 	goto st139;
 st139:
 	if ( ++p == pe )
 		goto _test_eof139;
 case 139:
-#line 2431 "wikitext_ragel.c"
+#line 2389 "ext/wikitext/wikitext_ragel.c"
 	switch( (*p) ) {
-		case 58: goto st96;
-		case 64: goto st21;
-		case 83: goto tr189;
-		case 95: goto st20;
-		case 115: goto tr189;
+		case 58u: goto st90;
+		case 64u: goto st15;
+		case 83u: goto tr189;
+		case 95u: goto st14;
+		case 115u: goto tr189;
 	}
-	if ( (*p) < 48 ) {
-		if ( 45 <= (*p) && (*p) <= 46 )
-			goto st20;
-	} else if ( (*p) > 57 ) {
-		if ( (*p) > 90 ) {
-			if ( 97 <= (*p) && (*p) <= 122 )
-				goto tr136;
-		} else if ( (*p) >= 65 )
-			goto tr136;
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st14;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto tr133;
+		} else if ( (*p) >= 65u )
+			goto tr133;
 	} else
-		goto tr136;
+		goto tr133;
 	goto tr174;
-tr142:
+tr139:
 #line 1 "NONE"
 	{te = p+1;}
-#line 442 "wikitext_ragel.rl"
+#line 443 "ext/wikitext/wikitext_ragel.rl"
 	{act = 44;}
 	goto st140;
 st140:
 	if ( ++p == pe )
 		goto _test_eof140;
 case 140:
-#line 2461 "wikitext_ragel.c"
+#line 2419 "ext/wikitext/wikitext_ragel.c"
 	switch( (*p) ) {
-		case 64: goto st21;
-		case 65: goto tr195;
-		case 95: goto st20;
-		case 97: goto tr195;
+		case 64u: goto st15;
+		case 65u: goto tr195;
+		case 95u: goto st14;
+		case 97u: goto tr195;
 	}
-	if ( (*p) < 48 ) {
-		if ( 45 <= (*p) && (*p) <= 46 )
-			goto st20;
-	} else if ( (*p) > 57 ) {
-		if ( (*p) > 90 ) {
-			if ( 98 <= (*p) && (*p) <= 122 )
-				goto tr136;
-		} else if ( (*p) >= 66 )
-			goto tr136;
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st14;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 98u <= (*p) && (*p) <= 122u )
+				goto tr133;
+		} else if ( (*p) >= 66u )
+			goto tr133;
 	} else
-		goto tr136;
+		goto tr133;
 	goto tr174;
 tr195:
 #line 1 "NONE"
 	{te = p+1;}
-#line 442 "wikitext_ragel.rl"
+#line 443 "ext/wikitext/wikitext_ragel.rl"
 	{act = 44;}
 	goto st141;
 st141:
 	if ( ++p == pe )
 		goto _test_eof141;
 case 141:
-#line 2490 "wikitext_ragel.c"
+#line 2448 "ext/wikitext/wikitext_ragel.c"
 	switch( (*p) ) {
-		case 64: goto st21;
-		case 73: goto tr196;
-		case 95: goto st20;
-		case 105: goto tr196;
+		case 64u: goto st15;
+		case 73u: goto tr196;
+		case 95u: goto st14;
+		case 105u: goto tr196;
 	}
-	if ( (*p) < 48 ) {
-		if ( 45 <= (*p) && (*p) <= 46 )
-			goto st20;
-	} else if ( (*p) > 57 ) {
-		if ( (*p) > 90 ) {
-			if ( 97 <= (*p) && (*p) <= 122 )
-				goto tr136;
-		} else if ( (*p) >= 65 )
-			goto tr136;
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st14;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto tr133;
+		} else if ( (*p) >= 65u )
+			goto tr133;
 	} else
-		goto tr136;
+		goto tr133;
 	goto tr174;
 tr196:
 #line 1 "NONE"
 	{te = p+1;}
-#line 442 "wikitext_ragel.rl"
+#line 443 "ext/wikitext/wikitext_ragel.rl"
 	{act = 44;}
 	goto st142;
 st142:
 	if ( ++p == pe )
 		goto _test_eof142;
 case 142:
-#line 2519 "wikitext_ragel.c"
+#line 2477 "ext/wikitext/wikitext_ragel.c"
 	switch( (*p) ) {
-		case 64: goto st21;
-		case 76: goto tr197;
-		case 95: goto st20;
-		case 108: goto tr197;
+		case 64u: goto st15;
+		case 76u: goto tr197;
+		case 95u: goto st14;
+		case 108u: goto tr197;
 	}
-	if ( (*p) < 48 ) {
-		if ( 45 <= (*p) && (*p) <= 46 )
-			goto st20;
-	} else if ( (*p) > 57 ) {
-		if ( (*p) > 90 ) {
-			if ( 97 <= (*p) && (*p) <= 122 )
-				goto tr136;
-		} else if ( (*p) >= 65 )
-			goto tr136;
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st14;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto tr133;
+		} else if ( (*p) >= 65u )
+			goto tr133;
 	} else
-		goto tr136;
+		goto tr133;
 	goto tr174;
 tr197:
 #line 1 "NONE"
 	{te = p+1;}
-#line 442 "wikitext_ragel.rl"
+#line 443 "ext/wikitext/wikitext_ragel.rl"
 	{act = 44;}
 	goto st143;
 st143:
 	if ( ++p == pe )
 		goto _test_eof143;
 case 143:
-#line 2548 "wikitext_ragel.c"
+#line 2506 "ext/wikitext/wikitext_ragel.c"
 	switch( (*p) ) {
-		case 64: goto st21;
-		case 84: goto tr198;
-		case 95: goto st20;
-		case 116: goto tr198;
+		case 64u: goto st15;
+		case 84u: goto tr198;
+		case 95u: goto st14;
+		case 116u: goto tr198;
 	}
-	if ( (*p) < 48 ) {
-		if ( 45 <= (*p) && (*p) <= 46 )
-			goto st20;
-	} else if ( (*p) > 57 ) {
-		if ( (*p) > 90 ) {
-			if ( 97 <= (*p) && (*p) <= 122 )
-				goto tr136;
-		} else if ( (*p) >= 65 )
-			goto tr136;
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st14;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto tr133;
+		} else if ( (*p) >= 65u )
+			goto tr133;
 	} else
-		goto tr136;
+		goto tr133;
 	goto tr174;
 tr198:
 #line 1 "NONE"
 	{te = p+1;}
-#line 442 "wikitext_ragel.rl"
+#line 443 "ext/wikitext/wikitext_ragel.rl"
 	{act = 44;}
 	goto st144;
 st144:
 	if ( ++p == pe )
 		goto _test_eof144;
 case 144:
-#line 2577 "wikitext_ragel.c"
+#line 2535 "ext/wikitext/wikitext_ragel.c"
 	switch( (*p) ) {
-		case 64: goto st21;
-		case 79: goto tr199;
-		case 95: goto st20;
-		case 111: goto tr199;
+		case 64u: goto st15;
+		case 79u: goto tr199;
+		case 95u: goto st14;
+		case 111u: goto tr199;
 	}
-	if ( (*p) < 48 ) {
-		if ( 45 <= (*p) && (*p) <= 46 )
-			goto st20;
-	} else if ( (*p) > 57 ) {
-		if ( (*p) > 90 ) {
-			if ( 97 <= (*p) && (*p) <= 122 )
-				goto tr136;
-		} else if ( (*p) >= 65 )
-			goto tr136;
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st14;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto tr133;
+		} else if ( (*p) >= 65u )
+			goto tr133;
 	} else
-		goto tr136;
+		goto tr133;
 	goto tr174;
 tr199:
 #line 1 "NONE"
 	{te = p+1;}
-#line 442 "wikitext_ragel.rl"
+#line 443 "ext/wikitext/wikitext_ragel.rl"
 	{act = 44;}
 	goto st145;
 st145:
 	if ( ++p == pe )
 		goto _test_eof145;
 case 145:
-#line 2606 "wikitext_ragel.c"
+#line 2564 "ext/wikitext/wikitext_ragel.c"
 	switch( (*p) ) {
-		case 58: goto st100;
-		case 64: goto st21;
-		case 95: goto st20;
+		case 58u: goto st94;
+		case 64u: goto st15;
+		case 95u: goto st14;
 	}
-	if ( (*p) < 48 ) {
-		if ( 45 <= (*p) && (*p) <= 46 )
-			goto st20;
-	} else if ( (*p) > 57 ) {
-		if ( (*p) > 90 ) {
-			if ( 97 <= (*p) && (*p) <= 122 )
-				goto tr136;
-		} else if ( (*p) >= 65 )
-			goto tr136;
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st14;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto tr133;
+		} else if ( (*p) >= 65u )
+			goto tr133;
 	} else
-		goto tr136;
+		goto tr133;
 	goto tr174;
-st100:
+st94:
 	if ( ++p == pe )
-		goto _test_eof100;
-case 100:
-	if ( (*p) == 95 )
-		goto st101;
-	if ( (*p) < 48 ) {
-		if ( 45 <= (*p) && (*p) <= 46 )
-			goto st101;
-	} else if ( (*p) > 57 ) {
-		if ( (*p) > 90 ) {
-			if ( 97 <= (*p) && (*p) <= 122 )
-				goto st101;
-		} else if ( (*p) >= 65 )
-			goto st101;
+		goto _test_eof94;
+case 94:
+	if ( (*p) == 95u )
+		goto st95;
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st95;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto st95;
+		} else if ( (*p) >= 65u )
+			goto st95;
 	} else
-		goto st101;
-	goto tr107;
-st101:
+		goto st95;
+	goto tr100;
+st95:
 	if ( ++p == pe )
-		goto _test_eof101;
-case 101:
+		goto _test_eof95;
+case 95:
 	switch( (*p) ) {
-		case 64: goto st102;
-		case 95: goto st101;
+		case 64u: goto st96;
+		case 95u: goto st95;
 	}
-	if ( (*p) < 48 ) {
-		if ( 45 <= (*p) && (*p) <= 46 )
-			goto st101;
-	} else if ( (*p) > 57 ) {
-		if ( (*p) > 90 ) {
-			if ( 97 <= (*p) && (*p) <= 122 )
-				goto st101;
-		} else if ( (*p) >= 65 )
-			goto st101;
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st95;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto st95;
+		} else if ( (*p) >= 65u )
+			goto st95;
 	} else
-		goto st101;
-	goto tr107;
-st102:
+		goto st95;
+	goto tr100;
+st96:
 	if ( ++p == pe )
-		goto _test_eof102;
-case 102:
-	if ( (*p) < 65 ) {
-		if ( 48 <= (*p) && (*p) <= 57 )
-			goto st103;
-	} else if ( (*p) > 90 ) {
-		if ( 97 <= (*p) && (*p) <= 122 )
-			goto st103;
+		goto _test_eof96;
+case 96:
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st97;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
+			goto st97;
 	} else
-		goto st103;
-	goto tr107;
-st103:
+		goto st97;
+	goto tr100;
+st97:
 	if ( ++p == pe )
-		goto _test_eof103;
-case 103:
-	if ( (*p) == 46 )
-		goto st104;
-	if ( (*p) < 65 ) {
-		if ( 48 <= (*p) && (*p) <= 57 )
-			goto st103;
-	} else if ( (*p) > 90 ) {
-		if ( 97 <= (*p) && (*p) <= 122 )
-			goto st103;
+		goto _test_eof97;
+case 97:
+	if ( (*p) == 46u )
+		goto st98;
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st97;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
+			goto st97;
 	} else
-		goto st103;
-	goto tr23;
-st104:
+		goto st97;
+	goto tr16;
+st98:
 	if ( ++p == pe )
-		goto _test_eof104;
-case 104:
-	if ( (*p) < 65 ) {
-		if ( 48 <= (*p) && (*p) <= 57 )
-			goto st103;
-	} else if ( (*p) > 90 ) {
-		if ( 97 <= (*p) && (*p) <= 122 )
-			goto st105;
+		goto _test_eof98;
+case 98:
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st97;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
+			goto st99;
 	} else
-		goto st105;
-	goto tr23;
-st105:
+		goto st99;
+	goto tr16;
+st99:
 	if ( ++p == pe )
-		goto _test_eof105;
-case 105:
-	if ( (*p) == 46 )
-		goto st104;
-	if ( (*p) < 65 ) {
-		if ( 48 <= (*p) && (*p) <= 57 )
-			goto st103;
-	} else if ( (*p) > 90 ) {
-		if ( 97 <= (*p) && (*p) <= 122 )
-			goto tr118;
+		goto _test_eof99;
+case 99:
+	if ( (*p) == 46u )
+		goto st98;
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st97;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
+			goto tr111;
 	} else
-		goto tr118;
-	goto tr23;
-tr118:
+		goto tr111;
+	goto tr16;
+tr111:
 #line 1 "NONE"
 	{te = p+1;}
-#line 297 "wikitext_ragel.rl"
+#line 298 "ext/wikitext/wikitext_ragel.rl"
 	{act = 21;}
 	goto st146;
 st146:
 	if ( ++p == pe )
 		goto _test_eof146;
 case 146:
-#line 2728 "wikitext_ragel.c"
-	if ( (*p) == 46 )
-		goto st104;
-	if ( (*p) < 65 ) {
-		if ( 48 <= (*p) && (*p) <= 57 )
-			goto st103;
-	} else if ( (*p) > 90 ) {
-		if ( 97 <= (*p) && (*p) <= 122 )
+#line 2686 "ext/wikitext/wikitext_ragel.c"
+	if ( (*p) == 46u )
+		goto st98;
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st97;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
 			goto tr201;
 	} else
 		goto tr201;
@@ -2739,21 +2697,21 @@ case 146:
 tr201:
 #line 1 "NONE"
 	{te = p+1;}
-#line 297 "wikitext_ragel.rl"
+#line 298 "ext/wikitext/wikitext_ragel.rl"
 	{act = 21;}
 	goto st147;
 st147:
 	if ( ++p == pe )
 		goto _test_eof147;
 case 147:
-#line 2750 "wikitext_ragel.c"
-	if ( (*p) == 46 )
-		goto st104;
-	if ( (*p) < 65 ) {
-		if ( 48 <= (*p) && (*p) <= 57 )
-			goto st103;
-	} else if ( (*p) > 90 ) {
-		if ( 97 <= (*p) && (*p) <= 122 )
+#line 2708 "ext/wikitext/wikitext_ragel.c"
+	if ( (*p) == 46u )
+		goto st98;
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st97;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
 			goto tr202;
 	} else
 		goto tr202;
@@ -2761,21 +2719,21 @@ case 147:
 tr202:
 #line 1 "NONE"
 	{te = p+1;}
-#line 297 "wikitext_ragel.rl"
+#line 298 "ext/wikitext/wikitext_ragel.rl"
 	{act = 21;}
 	goto st148;
 st148:
 	if ( ++p == pe )
 		goto _test_eof148;
 case 148:
-#line 2772 "wikitext_ragel.c"
-	if ( (*p) == 46 )
-		goto st104;
-	if ( (*p) < 65 ) {
-		if ( 48 <= (*p) && (*p) <= 57 )
-			goto st103;
-	} else if ( (*p) > 90 ) {
-		if ( 97 <= (*p) && (*p) <= 122 )
+#line 2730 "ext/wikitext/wikitext_ragel.c"
+	if ( (*p) == 46u )
+		goto st98;
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st97;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
 			goto tr203;
 	} else
 		goto tr203;
@@ -2783,124 +2741,166 @@ case 148:
 tr203:
 #line 1 "NONE"
 	{te = p+1;}
-#line 297 "wikitext_ragel.rl"
+#line 298 "ext/wikitext/wikitext_ragel.rl"
 	{act = 21;}
 	goto st149;
 st149:
 	if ( ++p == pe )
 		goto _test_eof149;
 case 149:
-#line 2794 "wikitext_ragel.c"
-	if ( (*p) == 46 )
-		goto st104;
-	if ( (*p) < 65 ) {
-		if ( 48 <= (*p) && (*p) <= 57 )
-			goto st103;
-	} else if ( (*p) > 90 ) {
-		if ( 97 <= (*p) && (*p) <= 122 )
-			goto st103;
+#line 2752 "ext/wikitext/wikitext_ragel.c"
+	if ( (*p) == 46u )
+		goto st98;
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st97;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
+			goto st97;
 	} else
-		goto st103;
+		goto st97;
 	goto tr191;
-tr143:
+tr140:
 #line 1 "NONE"
 	{te = p+1;}
-#line 442 "wikitext_ragel.rl"
+#line 443 "ext/wikitext/wikitext_ragel.rl"
 	{act = 44;}
 	goto st150;
 st150:
 	if ( ++p == pe )
 		goto _test_eof150;
 case 150:
-#line 2816 "wikitext_ragel.c"
+#line 2774 "ext/wikitext/wikitext_ragel.c"
 	switch( (*p) ) {
-		case 64: goto st21;
-		case 86: goto tr204;
-		case 95: goto st20;
-		case 118: goto tr204;
+		case 64u: goto st15;
+		case 86u: goto tr204;
+		case 95u: goto st14;
+		case 118u: goto tr204;
 	}
-	if ( (*p) < 48 ) {
-		if ( 45 <= (*p) && (*p) <= 46 )
-			goto st20;
-	} else if ( (*p) > 57 ) {
-		if ( (*p) > 90 ) {
-			if ( 97 <= (*p) && (*p) <= 122 )
-				goto tr136;
-		} else if ( (*p) >= 65 )
-			goto tr136;
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st14;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto tr133;
+		} else if ( (*p) >= 65u )
+			goto tr133;
 	} else
-		goto tr136;
+		goto tr133;
 	goto tr174;
 tr204:
 #line 1 "NONE"
 	{te = p+1;}
-#line 442 "wikitext_ragel.rl"
+#line 443 "ext/wikitext/wikitext_ragel.rl"
 	{act = 44;}
 	goto st151;
 st151:
 	if ( ++p == pe )
 		goto _test_eof151;
 case 151:
-#line 2845 "wikitext_ragel.c"
+#line 2803 "ext/wikitext/wikitext_ragel.c"
 	switch( (*p) ) {
-		case 64: goto st21;
-		case 78: goto tr189;
-		case 95: goto st20;
-		case 110: goto tr189;
+		case 64u: goto st15;
+		case 78u: goto tr189;
+		case 95u: goto st14;
+		case 110u: goto tr189;
 	}
-	if ( (*p) < 48 ) {
-		if ( 45 <= (*p) && (*p) <= 46 )
-			goto st20;
-	} else if ( (*p) > 57 ) {
-		if ( (*p) > 90 ) {
-			if ( 97 <= (*p) && (*p) <= 122 )
-				goto tr136;
-		} else if ( (*p) >= 65 )
-			goto tr136;
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st14;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto tr133;
+		} else if ( (*p) >= 65u )
+			goto tr133;
 	} else
-		goto tr136;
+		goto tr133;
 	goto tr174;
 st152:
 	if ( ++p == pe )
 		goto _test_eof152;
 case 152:
-	if ( (*p) == 91 )
+	if ( (*p) == 91u )
 		goto tr206;
 	goto tr205;
 st153:
 	if ( ++p == pe )
 		goto _test_eof153;
 case 153:
-	if ( (*p) == 93 )
+	if ( (*p) == 93u )
 		goto tr208;
 	goto tr207;
 st154:
 	if ( ++p == pe )
 		goto _test_eof154;
 case 154:
-	if ( (*p) == 123 )
+	if ( (*p) == 123u )
 		goto tr210;
 	goto tr209;
 st155:
 	if ( ++p == pe )
 		goto _test_eof155;
 case 155:
-	if ( (*p) == 125 )
+	if ( (*p) == 125u )
 		goto tr212;
 	goto tr211;
+st100:
+	if ( ++p == pe )
+		goto _test_eof100;
+case 100:
+	if ( 128u <= (*p) && (*p) <= 191u )
+		goto tr112;
+	goto st0;
+st101:
+	if ( ++p == pe )
+		goto _test_eof101;
+case 101:
+	if ( 128u <= (*p) && (*p) <= 191u )
+		goto st102;
+	goto st0;
+st102:
+	if ( ++p == pe )
+		goto _test_eof102;
+case 102:
+	if ( 128u <= (*p) && (*p) <= 191u )
+		goto tr115;
+	goto st0;
+st103:
+	if ( ++p == pe )
+		goto _test_eof103;
+case 103:
+	if ( 128u <= (*p) && (*p) <= 191u )
+		goto st104;
+	goto st0;
+st104:
+	if ( ++p == pe )
+		goto _test_eof104;
+case 104:
+	if ( 128u <= (*p) && (*p) <= 191u )
+		goto st105;
+	goto st0;
+st105:
+	if ( ++p == pe )
+		goto _test_eof105;
+case 105:
+	if ( 128u <= (*p) && (*p) <= 191u )
+		goto tr118;
+	goto st0;
 	}
 	_test_eof106: cs = 106; goto _test_eof; 
+	_test_eof107: cs = 107; goto _test_eof; 
+	_test_eof108: cs = 108; goto _test_eof; 
+	_test_eof109: cs = 109; goto _test_eof; 
+	_test_eof110: cs = 110; goto _test_eof; 
+	_test_eof111: cs = 111; goto _test_eof; 
 	_test_eof1: cs = 1; goto _test_eof; 
 	_test_eof2: cs = 2; goto _test_eof; 
 	_test_eof3: cs = 3; goto _test_eof; 
 	_test_eof4: cs = 4; goto _test_eof; 
 	_test_eof5: cs = 5; goto _test_eof; 
 	_test_eof6: cs = 6; goto _test_eof; 
-	_test_eof107: cs = 107; goto _test_eof; 
-	_test_eof108: cs = 108; goto _test_eof; 
-	_test_eof109: cs = 109; goto _test_eof; 
-	_test_eof110: cs = 110; goto _test_eof; 
-	_test_eof111: cs = 111; goto _test_eof; 
 	_test_eof7: cs = 7; goto _test_eof; 
 	_test_eof8: cs = 8; goto _test_eof; 
 	_test_eof9: cs = 9; goto _test_eof; 
@@ -2908,22 +2908,16 @@ case 155:
 	_test_eof11: cs = 11; goto _test_eof; 
 	_test_eof12: cs = 12; goto _test_eof; 
 	_test_eof13: cs = 13; goto _test_eof; 
-	_test_eof14: cs = 14; goto _test_eof; 
-	_test_eof15: cs = 15; goto _test_eof; 
-	_test_eof16: cs = 16; goto _test_eof; 
-	_test_eof17: cs = 17; goto _test_eof; 
-	_test_eof18: cs = 18; goto _test_eof; 
-	_test_eof19: cs = 19; goto _test_eof; 
 	_test_eof112: cs = 112; goto _test_eof; 
 	_test_eof113: cs = 113; goto _test_eof; 
 	_test_eof114: cs = 114; goto _test_eof; 
 	_test_eof115: cs = 115; goto _test_eof; 
 	_test_eof116: cs = 116; goto _test_eof; 
-	_test_eof20: cs = 20; goto _test_eof; 
-	_test_eof21: cs = 21; goto _test_eof; 
-	_test_eof22: cs = 22; goto _test_eof; 
-	_test_eof23: cs = 23; goto _test_eof; 
-	_test_eof24: cs = 24; goto _test_eof; 
+	_test_eof14: cs = 14; goto _test_eof; 
+	_test_eof15: cs = 15; goto _test_eof; 
+	_test_eof16: cs = 16; goto _test_eof; 
+	_test_eof17: cs = 17; goto _test_eof; 
+	_test_eof18: cs = 18; goto _test_eof; 
 	_test_eof117: cs = 117; goto _test_eof; 
 	_test_eof118: cs = 118; goto _test_eof; 
 	_test_eof119: cs = 119; goto _test_eof; 
@@ -2936,6 +2930,12 @@ case 155:
 	_test_eof126: cs = 126; goto _test_eof; 
 	_test_eof127: cs = 127; goto _test_eof; 
 	_test_eof128: cs = 128; goto _test_eof; 
+	_test_eof19: cs = 19; goto _test_eof; 
+	_test_eof20: cs = 20; goto _test_eof; 
+	_test_eof21: cs = 21; goto _test_eof; 
+	_test_eof22: cs = 22; goto _test_eof; 
+	_test_eof23: cs = 23; goto _test_eof; 
+	_test_eof24: cs = 24; goto _test_eof; 
 	_test_eof25: cs = 25; goto _test_eof; 
 	_test_eof26: cs = 26; goto _test_eof; 
 	_test_eof27: cs = 27; goto _test_eof; 
@@ -3001,23 +3001,17 @@ case 155:
 	_test_eof87: cs = 87; goto _test_eof; 
 	_test_eof88: cs = 88; goto _test_eof; 
 	_test_eof89: cs = 89; goto _test_eof; 
-	_test_eof90: cs = 90; goto _test_eof; 
-	_test_eof91: cs = 91; goto _test_eof; 
-	_test_eof92: cs = 92; goto _test_eof; 
-	_test_eof93: cs = 93; goto _test_eof; 
-	_test_eof94: cs = 94; goto _test_eof; 
-	_test_eof95: cs = 95; goto _test_eof; 
 	_test_eof129: cs = 129; goto _test_eof; 
 	_test_eof130: cs = 130; goto _test_eof; 
 	_test_eof131: cs = 131; goto _test_eof; 
 	_test_eof132: cs = 132; goto _test_eof; 
 	_test_eof133: cs = 133; goto _test_eof; 
 	_test_eof134: cs = 134; goto _test_eof; 
-	_test_eof96: cs = 96; goto _test_eof; 
-	_test_eof97: cs = 97; goto _test_eof; 
-	_test_eof98: cs = 98; goto _test_eof; 
+	_test_eof90: cs = 90; goto _test_eof; 
+	_test_eof91: cs = 91; goto _test_eof; 
+	_test_eof92: cs = 92; goto _test_eof; 
 	_test_eof135: cs = 135; goto _test_eof; 
-	_test_eof99: cs = 99; goto _test_eof; 
+	_test_eof93: cs = 93; goto _test_eof; 
 	_test_eof136: cs = 136; goto _test_eof; 
 	_test_eof137: cs = 137; goto _test_eof; 
 	_test_eof138: cs = 138; goto _test_eof; 
@@ -3028,12 +3022,12 @@ case 155:
 	_test_eof143: cs = 143; goto _test_eof; 
 	_test_eof144: cs = 144; goto _test_eof; 
 	_test_eof145: cs = 145; goto _test_eof; 
-	_test_eof100: cs = 100; goto _test_eof; 
-	_test_eof101: cs = 101; goto _test_eof; 
-	_test_eof102: cs = 102; goto _test_eof; 
-	_test_eof103: cs = 103; goto _test_eof; 
-	_test_eof104: cs = 104; goto _test_eof; 
-	_test_eof105: cs = 105; goto _test_eof; 
+	_test_eof94: cs = 94; goto _test_eof; 
+	_test_eof95: cs = 95; goto _test_eof; 
+	_test_eof96: cs = 96; goto _test_eof; 
+	_test_eof97: cs = 97; goto _test_eof; 
+	_test_eof98: cs = 98; goto _test_eof; 
+	_test_eof99: cs = 99; goto _test_eof; 
 	_test_eof146: cs = 146; goto _test_eof; 
 	_test_eof147: cs = 147; goto _test_eof; 
 	_test_eof148: cs = 148; goto _test_eof; 
@@ -3044,6 +3038,12 @@ case 155:
 	_test_eof153: cs = 153; goto _test_eof; 
 	_test_eof154: cs = 154; goto _test_eof; 
 	_test_eof155: cs = 155; goto _test_eof; 
+	_test_eof100: cs = 100; goto _test_eof; 
+	_test_eof101: cs = 101; goto _test_eof; 
+	_test_eof102: cs = 102; goto _test_eof; 
+	_test_eof103: cs = 103; goto _test_eof; 
+	_test_eof104: cs = 104; goto _test_eof; 
+	_test_eof105: cs = 105; goto _test_eof; 
 
 	_test_eof: {}
 	if ( p == eof )
@@ -3054,29 +3054,29 @@ case 155:
 	case 109: goto tr154;
 	case 110: goto tr155;
 	case 111: goto tr156;
-	case 7: goto tr7;
-	case 8: goto tr7;
-	case 9: goto tr7;
-	case 10: goto tr7;
-	case 11: goto tr7;
-	case 12: goto tr7;
-	case 13: goto tr7;
-	case 14: goto tr7;
-	case 15: goto tr7;
-	case 16: goto tr7;
-	case 17: goto tr7;
-	case 18: goto tr7;
-	case 19: goto tr7;
+	case 1: goto tr0;
+	case 2: goto tr0;
+	case 3: goto tr0;
+	case 4: goto tr0;
+	case 5: goto tr0;
+	case 6: goto tr0;
+	case 7: goto tr0;
+	case 8: goto tr0;
+	case 9: goto tr0;
+	case 10: goto tr0;
+	case 11: goto tr0;
+	case 12: goto tr0;
+	case 13: goto tr0;
 	case 112: goto tr160;
 	case 113: goto tr160;
 	case 114: goto tr160;
 	case 115: goto tr160;
 	case 116: goto tr155;
-	case 20: goto tr23;
-	case 21: goto tr23;
-	case 22: goto tr23;
-	case 23: goto tr23;
-	case 24: goto tr23;
+	case 14: goto tr16;
+	case 15: goto tr16;
+	case 16: goto tr16;
+	case 17: goto tr16;
+	case 18: goto tr16;
 	case 117: goto tr166;
 	case 118: goto tr166;
 	case 119: goto tr166;
@@ -3089,88 +3089,88 @@ case 155:
 	case 126: goto tr170;
 	case 127: goto tr174;
 	case 128: goto tr175;
-	case 25: goto tr30;
-	case 26: goto tr30;
-	case 27: goto tr30;
-	case 28: goto tr30;
-	case 29: goto tr30;
-	case 30: goto tr30;
-	case 31: goto tr30;
-	case 32: goto tr30;
-	case 33: goto tr30;
-	case 34: goto tr30;
-	case 35: goto tr30;
-	case 36: goto tr30;
-	case 37: goto tr30;
-	case 38: goto tr30;
-	case 39: goto tr30;
-	case 40: goto tr30;
-	case 41: goto tr30;
-	case 42: goto tr30;
-	case 43: goto tr30;
-	case 44: goto tr30;
-	case 45: goto tr30;
-	case 46: goto tr30;
-	case 47: goto tr30;
-	case 48: goto tr30;
-	case 49: goto tr30;
-	case 50: goto tr30;
-	case 51: goto tr30;
-	case 52: goto tr30;
-	case 53: goto tr30;
-	case 54: goto tr30;
-	case 55: goto tr30;
-	case 56: goto tr30;
-	case 57: goto tr30;
-	case 58: goto tr30;
-	case 59: goto tr30;
-	case 60: goto tr30;
-	case 61: goto tr30;
-	case 62: goto tr30;
-	case 63: goto tr30;
-	case 64: goto tr30;
-	case 65: goto tr30;
-	case 66: goto tr30;
-	case 67: goto tr30;
-	case 68: goto tr30;
-	case 69: goto tr30;
-	case 70: goto tr30;
-	case 71: goto tr30;
-	case 72: goto tr30;
-	case 73: goto tr30;
-	case 74: goto tr30;
-	case 75: goto tr30;
-	case 76: goto tr30;
-	case 77: goto tr30;
-	case 78: goto tr30;
-	case 79: goto tr30;
-	case 80: goto tr30;
-	case 81: goto tr30;
-	case 82: goto tr30;
-	case 83: goto tr30;
-	case 84: goto tr30;
-	case 85: goto tr30;
-	case 86: goto tr30;
-	case 87: goto tr30;
-	case 88: goto tr30;
-	case 89: goto tr30;
-	case 90: goto tr30;
-	case 91: goto tr30;
-	case 92: goto tr30;
-	case 93: goto tr30;
-	case 94: goto tr30;
-	case 95: goto tr30;
+	case 19: goto tr23;
+	case 20: goto tr23;
+	case 21: goto tr23;
+	case 22: goto tr23;
+	case 23: goto tr23;
+	case 24: goto tr23;
+	case 25: goto tr23;
+	case 26: goto tr23;
+	case 27: goto tr23;
+	case 28: goto tr23;
+	case 29: goto tr23;
+	case 30: goto tr23;
+	case 31: goto tr23;
+	case 32: goto tr23;
+	case 33: goto tr23;
+	case 34: goto tr23;
+	case 35: goto tr23;
+	case 36: goto tr23;
+	case 37: goto tr23;
+	case 38: goto tr23;
+	case 39: goto tr23;
+	case 40: goto tr23;
+	case 41: goto tr23;
+	case 42: goto tr23;
+	case 43: goto tr23;
+	case 44: goto tr23;
+	case 45: goto tr23;
+	case 46: goto tr23;
+	case 47: goto tr23;
+	case 48: goto tr23;
+	case 49: goto tr23;
+	case 50: goto tr23;
+	case 51: goto tr23;
+	case 52: goto tr23;
+	case 53: goto tr23;
+	case 54: goto tr23;
+	case 55: goto tr23;
+	case 56: goto tr23;
+	case 57: goto tr23;
+	case 58: goto tr23;
+	case 59: goto tr23;
+	case 60: goto tr23;
+	case 61: goto tr23;
+	case 62: goto tr23;
+	case 63: goto tr23;
+	case 64: goto tr23;
+	case 65: goto tr23;
+	case 66: goto tr23;
+	case 67: goto tr23;
+	case 68: goto tr23;
+	case 69: goto tr23;
+	case 70: goto tr23;
+	case 71: goto tr23;
+	case 72: goto tr23;
+	case 73: goto tr23;
+	case 74: goto tr23;
+	case 75: goto tr23;
+	case 76: goto tr23;
+	case 77: goto tr23;
+	case 78: goto tr23;
+	case 79: goto tr23;
+	case 80: goto tr23;
+	case 81: goto tr23;
+	case 82: goto tr23;
+	case 83: goto tr23;
+	case 84: goto tr23;
+	case 85: goto tr23;
+	case 86: goto tr23;
+	case 87: goto tr23;
+	case 88: goto tr23;
+	case 89: goto tr23;
 	case 129: goto tr184;
 	case 130: goto tr184;
 	case 131: goto tr186;
 	case 132: goto tr174;
 	case 133: goto tr174;
 	case 134: goto tr174;
-	case 96: goto tr107;
-	case 97: goto tr107;
-	case 98: goto tr107;
+	case 90: goto tr100;
+	case 91: goto tr100;
+	case 92: goto tr100;
 	case 135: goto tr191;
-	case 99: goto tr111;
+	case 93: goto tr104;
 	case 136: goto tr174;
 	case 137: goto tr174;
 	case 138: goto tr174;
@@ -3181,12 +3181,12 @@ case 155:
 	case 143: goto tr174;
 	case 144: goto tr174;
 	case 145: goto tr174;
-	case 100: goto tr107;
-	case 101: goto tr107;
-	case 102: goto tr107;
-	case 103: goto tr23;
-	case 104: goto tr23;
-	case 105: goto tr23;
+	case 94: goto tr100;
+	case 95: goto tr100;
+	case 96: goto tr100;
+	case 97: goto tr16;
+	case 98: goto tr16;
+	case 99: goto tr16;
 	case 146: goto tr191;
 	case 147: goto tr191;
 	case 148: goto tr191;
@@ -3203,7 +3203,7 @@ case 155:
 	_out: {}
 	}
 
-#line 526 "wikitext_ragel.rl"
+#line 527 "ext/wikitext/wikitext_ragel.rl"
     if (cs == wikitext_error)
         rb_raise(eWikitextParserError, "failed before finding a token");
     else if (out->type == NO_TOKEN)

--- a/ext/wikitext/wikitext_ragel.c
+++ b/ext/wikitext/wikitext_ragel.c
@@ -1,5 +1,5 @@
 
-#line 1 "ext/wikitext/wikitext_ragel.rl"
+#line 1 "wikitext_ragel.rl"
 // Copyright 2008-present Greg Hurrell. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -41,15 +41,15 @@
 #define NEXT_CHAR() (*(p + 1))
 
 
-#line 45 "ext/wikitext/wikitext_ragel.c"
-static const int wikitext_start = 106;
-static const int wikitext_first_final = 106;
+#line 45 "wikitext_ragel.c"
+static const int wikitext_start = 109;
+static const int wikitext_first_final = 109;
 static const int wikitext_error = 0;
 
-static const int wikitext_en_main = 106;
+static const int wikitext_en_main = 109;
 
 
-#line 484 "ext/wikitext/wikitext_ragel.rl"
+#line 490 "wikitext_ragel.rl"
 
 
 // for now we use the scanner as a tokenizer that returns one token at a time, just like ANTLR
@@ -91,8 +91,8 @@ void next_token(token_t *out, token_t *last_token, unsigned char *p, unsigned ch
     unsigned char *ts;        // token start (scanner)
     unsigned char *te;        // token end (scanner)
     int     act;        // identity of last patterned matched (scanner)
-    
-#line 96 "ext/wikitext/wikitext_ragel.c"
+
+#line 96 "wikitext_ragel.c"
 	{
 	cs = wikitext_start;
 	ts = 0;
@@ -100,280 +100,280 @@ void next_token(token_t *out, token_t *last_token, unsigned char *p, unsigned ch
 	act = 0;
 	}
 
-#line 526 "ext/wikitext/wikitext_ragel.rl"
-    
-#line 106 "ext/wikitext/wikitext_ragel.c"
+#line 532 "wikitext_ragel.rl"
+
+#line 106 "wikitext_ragel.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
 	switch ( cs )
 	{
 tr0:
-#line 382 "ext/wikitext/wikitext_ragel.rl"
+#line 388 "wikitext_ragel.rl"
 	{{p = ((te))-1;}{
             EMIT(AMP);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
+	goto st109;
 tr3:
-#line 370 "ext/wikitext/wikitext_ragel.rl"
+#line 376 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(DECIMAL_ENTITY);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
+	goto st109;
 tr5:
-#line 364 "ext/wikitext/wikitext_ragel.rl"
+#line 370 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(HEX_ENTITY);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
+	goto st109;
 tr7:
-#line 358 "ext/wikitext/wikitext_ragel.rl"
+#line 364 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(NAMED_ENTITY);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
+	goto st109;
 tr11:
-#line 352 "ext/wikitext/wikitext_ragel.rl"
+#line 358 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(AMP_ENTITY);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
+	goto st109;
 tr15:
-#line 346 "ext/wikitext/wikitext_ragel.rl"
+#line 352 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(QUOT_ENTITY);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
+	goto st109;
 tr16:
 #line 1 "NONE"
 	{	switch( act ) {
 	case 21:
 	{{p = ((te))-1;}
             EMIT(URI);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }
 	break;
 	case 22:
 	{{p = ((te))-1;}
             EMIT(MAIL);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }
 	break;
 	case 43:
 	{{p = ((te))-1;}
             EMIT(SPECIAL_URI_CHARS);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }
 	break;
 	case 44:
 	{{p = ((te))-1;}
             EMIT(ALNUM);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }
 	break;
 	case 45:
 	{{p = ((te))-1;}
             EMIT(PRINTABLE);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }
 	break;
 	}
 	}
-	goto st106;
+	goto st109;
 tr23:
-#line 388 "ext/wikitext/wikitext_ragel.rl"
+#line 394 "wikitext_ragel.rl"
 	{{p = ((te))-1;}{
             EMIT(LESS);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
+	goto st109;
 tr39:
-#line 127 "ext/wikitext/wikitext_ragel.rl"
+#line 133 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(BLOCKQUOTE_END);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
+	goto st109;
 tr41:
-#line 169 "ext/wikitext/wikitext_ragel.rl"
+#line 175 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(EM_END);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
+	goto st109;
 tr47:
-#line 97 "ext/wikitext/wikitext_ragel.rl"
+#line 103 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(NO_WIKI_END);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
+	goto st109;
 tr50:
-#line 115 "ext/wikitext/wikitext_ragel.rl"
+#line 121 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(PRE_END);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
+	goto st109;
 tr56:
-#line 157 "ext/wikitext/wikitext_ragel.rl"
+#line 163 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(STRONG_END);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
+	goto st109;
 tr58:
-#line 187 "ext/wikitext/wikitext_ragel.rl"
+#line 193 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(TT_END);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
+	goto st109;
 tr68:
-#line 121 "ext/wikitext/wikitext_ragel.rl"
+#line 127 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(BLOCKQUOTE_START);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
+	goto st109;
 tr70:
-#line 163 "ext/wikitext/wikitext_ragel.rl"
+#line 169 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(EM_START);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
+	goto st109;
 tr76:
-#line 91 "ext/wikitext/wikitext_ragel.rl"
+#line 97 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(NO_WIKI_START);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
+	goto st109;
 tr79:
-#line 103 "ext/wikitext/wikitext_ragel.rl"
+#line 109 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(PRE_START);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
+	goto st109;
 tr85:
-#line 151 "ext/wikitext/wikitext_ragel.rl"
+#line 157 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(STRONG_START);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
+	goto st109;
 tr87:
-#line 181 "ext/wikitext/wikitext_ragel.rl"
+#line 187 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(TT_START);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
+	goto st109;
 tr99:
-#line 109 "ext/wikitext/wikitext_ragel.rl"
+#line 115 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(PRE_START);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
+	goto st109;
 tr100:
-#line 443 "ext/wikitext/wikitext_ragel.rl"
+#line 449 "wikitext_ragel.rl"
 	{{p = ((te))-1;}{
             EMIT(ALNUM);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr104:
-#line 298 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr107:
+#line 304 "wikitext_ragel.rl"
 	{{p = ((te))-1;}{
             EMIT(URI);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr112:
-#line 56 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr115:
+#line 56 "wikitext_ragel.rl"
 	{
         out->code_point = ((uint32_t)(*(p - 1)) & 0x1f) << 6 |
             (*p & 0x3f);
     }
-#line 475 "ext/wikitext/wikitext_ragel.rl"
+#line 481 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(DEFAULT);
             out->column_stop = out->column_start + 1;
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr115:
-#line 62 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr118:
+#line 62 "wikitext_ragel.rl"
 	{
         out->code_point = ((uint32_t)(*(p - 2)) & 0x0f) << 12 |
             ((uint32_t)(*(p - 1)) & 0x3f) << 6 |
             (*p & 0x3f);
     }
-#line 475 "ext/wikitext/wikitext_ragel.rl"
+#line 481 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(DEFAULT);
             out->column_stop = out->column_start + 1;
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr118:
-#line 69 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr121:
+#line 69 "wikitext_ragel.rl"
 	{
         out->code_point = ((uint32_t)(*(p - 3)) & 0x07) << 18 |
             ((uint32_t)(*(p - 2)) & 0x3f) << 12 |
             ((uint32_t)(*(p - 1)) & 0x3f) << 6 |
             (*p & 0x3f);
     }
-#line 475 "ext/wikitext/wikitext_ragel.rl"
+#line 481 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(DEFAULT);
             out->column_stop = out->column_start + 1;
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr119:
-#line 51 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr122:
+#line 51 "wikitext_ragel.rl"
 	{
         out->code_point = *p & 0x7f;
     }
-#line 475 "ext/wikitext/wikitext_ragel.rl"
+#line 481 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(DEFAULT);
             out->column_stop = out->column_start + 1;
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr120:
-#line 424 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr123:
+#line 430 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(CRLF);
             out->column_stop = 1;
             out->line_stop++;
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-#line 51 "ext/wikitext/wikitext_ragel.rl"
+#line 51 "wikitext_ragel.rl"
 	{
         out->code_point = *p & 0x7f;
     }
-	goto st106;
-tr124:
-#line 376 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr127:
+#line 382 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(QUOT);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr125:
-#line 219 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr128:
+#line 225 "wikitext_ragel.rl"
 	{te = p+1;{
             if (out->column_start == 1              ||
                 last_token_type == OL               ||
@@ -383,11 +383,11 @@ tr125:
                 EMIT(OL);
             else
                 EMIT(PRINTABLE);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr129:
-#line 232 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr132:
+#line 238 "wikitext_ragel.rl"
 	{te = p+1;{
             if (out->column_start == 1              ||
                 last_token_type == OL               ||
@@ -397,43 +397,43 @@ tr129:
                 EMIT(UL);
             else
                 EMIT(PRINTABLE);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr143:
-#line 175 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr146:
+#line 181 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(TT);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr145:
-#line 328 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr148:
+#line 334 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(SEPARATOR);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr150:
-#line 424 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr153:
+#line 430 "wikitext_ragel.rl"
 	{te = p;p--;{
             EMIT(CRLF);
             out->column_stop = 1;
             out->line_stop++;
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr151:
-#line 424 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr154:
+#line 430 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(CRLF);
             out->column_stop = 1;
             out->line_stop++;
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr152:
-#line 207 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr155:
+#line 213 "wikitext_ragel.rl"
 	{te = p;p--;{
             if (out->column_start == 1 || last_token_type == BLOCKQUOTE)
             {
@@ -442,32 +442,32 @@ tr152:
             }
             else
                 EMIT(SPACE);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr154:
-#line 437 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr157:
+#line 443 "wikitext_ragel.rl"
 	{te = p;p--;{
             EMIT(SPECIAL_URI_CHARS);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr155:
-#line 455 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr158:
+#line 461 "wikitext_ragel.rl"
 	{te = p;p--;{
             EMIT(PRINTABLE);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr156:
-#line 382 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr159:
+#line 388 "wikitext_ragel.rl"
 	{te = p;p--;{
             EMIT(AMP);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr160:
-#line 133 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr163:
+#line 139 "wikitext_ragel.rl"
 	{te = p;p--;{
             if (DISTANCE() == 5)
                 EMIT(STRONG_EM);
@@ -482,11 +482,11 @@ tr160:
                 EMIT(EM);
             else
                 EMIT(PRINTABLE);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr164:
-#line 133 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr167:
+#line 139 "wikitext_ragel.rl"
 	{te = p+1;{
             if (DISTANCE() == 5)
                 EMIT(STRONG_EM);
@@ -501,39 +501,39 @@ tr164:
                 EMIT(EM);
             else
                 EMIT(PRINTABLE);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr166:
-#line 304 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr169:
+#line 310 "wikitext_ragel.rl"
 	{te = p;p--;{
             EMIT(MAIL);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr170:
-#line 310 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr173:
+#line 316 "wikitext_ragel.rl"
 	{te = p;p--;{
             EMIT(PATH);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr174:
-#line 443 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr177:
+#line 449 "wikitext_ragel.rl"
 	{te = p;p--;{
             EMIT(ALNUM);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr175:
-#line 388 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr178:
+#line 394 "wikitext_ragel.rl"
 	{te = p;p--;{
             EMIT(LESS);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr184:
-#line 245 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr187:
+#line 251 "wikitext_ragel.rl"
 	{te = p;p--;{
             if (out->column_start == 1 || last_token_type == BLOCKQUOTE || last_token_type == BLOCKQUOTE_START)
             {
@@ -583,11 +583,11 @@ tr184:
                 REWIND();
                 EMIT(PRINTABLE);
             }
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr186:
-#line 194 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr189:
+#line 200 "wikitext_ragel.rl"
 	{te = p;p--;{
             if (out->column_start == 1 || last_token_type == BLOCKQUOTE)
                 EMIT(BLOCKQUOTE);
@@ -596,11 +596,11 @@ tr186:
                 REWIND();
                 EMIT(GREATER);
             }
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr187:
-#line 194 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr190:
+#line 200 "wikitext_ragel.rl"
 	{te = p+1;{
             if (out->column_start == 1 || last_token_type == BLOCKQUOTE)
                 EMIT(BLOCKQUOTE);
@@ -609,220 +609,220 @@ tr187:
                 REWIND();
                 EMIT(GREATER);
             }
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr191:
-#line 298 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr194:
+#line 304 "wikitext_ragel.rl"
 	{te = p;p--;{
             EMIT(URI);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr205:
-#line 334 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr208:
+#line 340 "wikitext_ragel.rl"
 	{te = p;p--;{
             EMIT(EXT_LINK_START);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr206:
-#line 316 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr209:
+#line 322 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(LINK_START);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr207:
-#line 340 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr210:
+#line 346 "wikitext_ragel.rl"
 	{te = p;p--;{
             EMIT(EXT_LINK_END);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr208:
-#line 322 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr211:
+#line 328 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(LINK_END);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr209:
-#line 412 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr212:
+#line 418 "wikitext_ragel.rl"
 	{te = p;p--;{
             EMIT(LEFT_CURLY);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr210:
-#line 400 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr213:
+#line 406 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(IMG_START);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr211:
-#line 418 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr214:
+#line 424 "wikitext_ragel.rl"
 	{te = p;p--;{
             EMIT(RIGHT_CURLY);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-tr212:
-#line 406 "ext/wikitext/wikitext_ragel.rl"
+	goto st109;
+tr215:
+#line 412 "wikitext_ragel.rl"
 	{te = p+1;{
             EMIT(IMG_END);
-            {p++; cs = 106; goto _out;}
+            {p++; cs = 109; goto _out;}
         }}
-	goto st106;
-st106:
+	goto st109;
+st109:
 #line 1 "NONE"
 	{ts = 0;}
 	if ( ++p == pe )
-		goto _test_eof106;
-case 106:
+		goto _test_eof109;
+case 109:
 #line 1 "NONE"
 	{ts = p;}
-#line 687 "ext/wikitext/wikitext_ragel.c"
+#line 687 "wikitext_ragel.c"
 	switch( (*p) ) {
-		case 10u: goto tr120;
-		case 13u: goto tr121;
-		case 32u: goto tr122;
-		case 33u: goto st109;
-		case 34u: goto tr124;
-		case 35u: goto tr125;
-		case 38u: goto tr127;
-		case 39u: goto st112;
-		case 42u: goto tr129;
-		case 43u: goto st110;
-		case 45u: goto tr130;
-		case 46u: goto tr131;
-		case 47u: goto st123;
-		case 60u: goto tr134;
-		case 61u: goto tr135;
-		case 62u: goto tr136;
-		case 64u: goto st110;
-		case 70u: goto tr137;
-		case 72u: goto tr138;
-		case 77u: goto tr139;
-		case 83u: goto tr140;
-		case 91u: goto st152;
-		case 92u: goto st110;
-		case 93u: goto st153;
-		case 94u: goto st110;
-		case 95u: goto tr130;
-		case 96u: goto tr143;
-		case 102u: goto tr137;
-		case 104u: goto tr138;
-		case 109u: goto tr139;
-		case 115u: goto tr140;
-		case 123u: goto st154;
-		case 124u: goto tr145;
-		case 125u: goto st155;
-		case 126u: goto st110;
-		case 127u: goto tr119;
+		case 10u: goto tr123;
+		case 13u: goto tr124;
+		case 32u: goto tr125;
+		case 33u: goto st112;
+		case 34u: goto tr127;
+		case 35u: goto tr128;
+		case 38u: goto tr130;
+		case 39u: goto st115;
+		case 42u: goto tr132;
+		case 43u: goto st113;
+		case 45u: goto tr133;
+		case 46u: goto tr134;
+		case 47u: goto st126;
+		case 60u: goto tr137;
+		case 61u: goto tr138;
+		case 62u: goto tr139;
+		case 64u: goto st113;
+		case 70u: goto tr140;
+		case 72u: goto tr141;
+		case 77u: goto tr142;
+		case 83u: goto tr143;
+		case 91u: goto st155;
+		case 92u: goto st113;
+		case 93u: goto st156;
+		case 94u: goto st113;
+		case 95u: goto tr133;
+		case 96u: goto tr146;
+		case 102u: goto tr140;
+		case 104u: goto tr141;
+		case 109u: goto tr142;
+		case 115u: goto tr143;
+		case 123u: goto st157;
+		case 124u: goto tr148;
+		case 125u: goto st158;
+		case 126u: goto st113;
+		case 127u: goto tr122;
 	}
 	if ( (*p) < 58u ) {
 		if ( (*p) < 36u ) {
 			if ( 1u <= (*p) && (*p) <= 31u )
-				goto tr119;
+				goto tr122;
 		} else if ( (*p) > 37u ) {
 			if ( (*p) > 44u ) {
 				if ( 48u <= (*p) && (*p) <= 57u )
-					goto tr133;
+					goto tr136;
 			} else if ( (*p) >= 40u )
-				goto st109;
+				goto st112;
 		} else
-			goto st110;
+			goto st113;
 	} else if ( (*p) > 63u ) {
 		if ( (*p) < 194u ) {
 			if ( 65u <= (*p) && (*p) <= 122u )
-				goto tr133;
+				goto tr136;
 		} else if ( (*p) > 223u ) {
 			if ( (*p) > 239u ) {
 				if ( 240u <= (*p) && (*p) <= 244u )
-					goto st103;
+					goto st106;
 			} else if ( (*p) >= 224u )
-				goto st101;
+				goto st104;
 		} else
-			goto st100;
+			goto st103;
 	} else
-		goto st109;
+		goto st112;
 	goto st0;
 st0:
 cs = 0;
 	goto _out;
-tr121:
-#line 51 "ext/wikitext/wikitext_ragel.rl"
+tr124:
+#line 51 "wikitext_ragel.rl"
 	{
         out->code_point = *p & 0x7f;
     }
-	goto st107;
-st107:
-	if ( ++p == pe )
-		goto _test_eof107;
-case 107:
-#line 766 "ext/wikitext/wikitext_ragel.c"
-	if ( (*p) == 10u )
-		goto tr151;
-	goto tr150;
-tr122:
-#line 46 "ext/wikitext/wikitext_ragel.rl"
-	{
-        MARK();
-    }
-	goto st108;
-st108:
-	if ( ++p == pe )
-		goto _test_eof108;
-case 108:
-#line 780 "ext/wikitext/wikitext_ragel.c"
-	if ( (*p) == 32u )
-		goto st108;
-	goto tr152;
-st109:
-	if ( ++p == pe )
-		goto _test_eof109;
-case 109:
-	switch( (*p) ) {
-		case 33u: goto st109;
-		case 44u: goto st109;
-		case 46u: goto st109;
-		case 63u: goto st109;
-	}
-	if ( (*p) > 41u ) {
-		if ( 58u <= (*p) && (*p) <= 59u )
-			goto st109;
-	} else if ( (*p) >= 40u )
-		goto st109;
-	goto tr154;
+	goto st110;
 st110:
 	if ( ++p == pe )
 		goto _test_eof110;
 case 110:
-	switch( (*p) ) {
-		case 43u: goto st110;
-		case 45u: goto st110;
-		case 47u: goto st110;
-		case 64u: goto st110;
-		case 92u: goto st110;
-		case 126u: goto st110;
-	}
-	if ( (*p) > 37u ) {
-		if ( 94u <= (*p) && (*p) <= 95u )
-			goto st110;
-	} else if ( (*p) >= 36u )
-		goto st110;
-	goto tr155;
-tr127:
-#line 1 "NONE"
-	{te = p+1;}
+#line 766 "wikitext_ragel.c"
+	if ( (*p) == 10u )
+		goto tr154;
+	goto tr153;
+tr125:
+#line 46 "wikitext_ragel.rl"
+	{
+        MARK();
+    }
 	goto st111;
 st111:
 	if ( ++p == pe )
 		goto _test_eof111;
 case 111:
-#line 826 "ext/wikitext/wikitext_ragel.c"
+#line 780 "wikitext_ragel.c"
+	if ( (*p) == 32u )
+		goto st111;
+	goto tr155;
+st112:
+	if ( ++p == pe )
+		goto _test_eof112;
+case 112:
+	switch( (*p) ) {
+		case 33u: goto st112;
+		case 44u: goto st112;
+		case 46u: goto st112;
+		case 63u: goto st112;
+	}
+	if ( (*p) > 41u ) {
+		if ( 58u <= (*p) && (*p) <= 59u )
+			goto st112;
+	} else if ( (*p) >= 40u )
+		goto st112;
+	goto tr157;
+st113:
+	if ( ++p == pe )
+		goto _test_eof113;
+case 113:
+	switch( (*p) ) {
+		case 43u: goto st113;
+		case 45u: goto st113;
+		case 47u: goto st113;
+		case 64u: goto st113;
+		case 92u: goto st113;
+		case 126u: goto st113;
+	}
+	if ( (*p) > 37u ) {
+		if ( 94u <= (*p) && (*p) <= 95u )
+			goto st113;
+	} else if ( (*p) >= 36u )
+		goto st113;
+	goto tr158;
+tr130:
+#line 1 "NONE"
+	{te = p+1;}
+	goto st114;
+st114:
+	if ( ++p == pe )
+		goto _test_eof114;
+case 114:
+#line 826 "wikitext_ragel.c"
 	switch( (*p) ) {
 		case 35u: goto st1;
 		case 97u: goto st7;
@@ -833,7 +833,7 @@ case 111:
 			goto st5;
 	} else if ( (*p) >= 65u )
 		goto st5;
-	goto tr156;
+	goto tr159;
 st1:
 	if ( ++p == pe )
 		goto _test_eof1;
@@ -1021,58 +1021,58 @@ case 13:
 	} else
 		goto st5;
 	goto tr0;
-st112:
-	if ( ++p == pe )
-		goto _test_eof112;
-case 112:
-	if ( (*p) == 39u )
-		goto st113;
-	goto tr160;
-st113:
-	if ( ++p == pe )
-		goto _test_eof113;
-case 113:
-	if ( (*p) == 39u )
-		goto st114;
-	goto tr160;
-st114:
-	if ( ++p == pe )
-		goto _test_eof114;
-case 114:
-	if ( (*p) == 39u )
-		goto st115;
-	goto tr160;
 st115:
 	if ( ++p == pe )
 		goto _test_eof115;
 case 115:
 	if ( (*p) == 39u )
-		goto tr164;
-	goto tr160;
-tr130:
-#line 1 "NONE"
-	{te = p+1;}
-#line 455 "ext/wikitext/wikitext_ragel.rl"
-	{act = 45;}
-	goto st116;
+		goto st116;
+	goto tr163;
 st116:
 	if ( ++p == pe )
 		goto _test_eof116;
 case 116:
-#line 1063 "ext/wikitext/wikitext_ragel.c"
+	if ( (*p) == 39u )
+		goto st117;
+	goto tr163;
+st117:
+	if ( ++p == pe )
+		goto _test_eof117;
+case 117:
+	if ( (*p) == 39u )
+		goto st118;
+	goto tr163;
+st118:
+	if ( ++p == pe )
+		goto _test_eof118;
+case 118:
+	if ( (*p) == 39u )
+		goto tr167;
+	goto tr163;
+tr133:
+#line 1 "NONE"
+	{te = p+1;}
+#line 461 "wikitext_ragel.rl"
+	{act = 45;}
+	goto st119;
+st119:
+	if ( ++p == pe )
+		goto _test_eof119;
+case 119:
+#line 1063 "wikitext_ragel.c"
 	switch( (*p) ) {
-		case 43u: goto st110;
-		case 45u: goto tr130;
-		case 47u: goto st110;
-		case 64u: goto tr165;
-		case 92u: goto st110;
-		case 94u: goto st110;
-		case 95u: goto tr130;
-		case 126u: goto st110;
+		case 43u: goto st113;
+		case 45u: goto tr133;
+		case 47u: goto st113;
+		case 64u: goto tr168;
+		case 92u: goto st113;
+		case 94u: goto st113;
+		case 95u: goto tr133;
+		case 126u: goto st113;
 	}
 	if ( (*p) < 46u ) {
 		if ( 36u <= (*p) && (*p) <= 37u )
-			goto st110;
+			goto st113;
 	} else if ( (*p) > 57u ) {
 		if ( (*p) > 90u ) {
 			if ( 97u <= (*p) && (*p) <= 122u )
@@ -1081,7 +1081,7 @@ case 116:
 			goto st14;
 	} else
 		goto st14;
-	goto tr155;
+	goto tr158;
 st14:
 	if ( ++p == pe )
 		goto _test_eof14;
@@ -1161,80 +1161,80 @@ case 18:
 tr22:
 #line 1 "NONE"
 	{te = p+1;}
-#line 304 "ext/wikitext/wikitext_ragel.rl"
-	{act = 22;}
-	goto st117;
-st117:
-	if ( ++p == pe )
-		goto _test_eof117;
-case 117:
-#line 1172 "ext/wikitext/wikitext_ragel.c"
-	if ( (*p) == 46u )
-		goto st17;
-	if ( (*p) < 65u ) {
-		if ( 48u <= (*p) && (*p) <= 57u )
-			goto st16;
-	} else if ( (*p) > 90u ) {
-		if ( 97u <= (*p) && (*p) <= 122u )
-			goto tr167;
-	} else
-		goto tr167;
-	goto tr166;
-tr167:
-#line 1 "NONE"
-	{te = p+1;}
-#line 304 "ext/wikitext/wikitext_ragel.rl"
-	{act = 22;}
-	goto st118;
-st118:
-	if ( ++p == pe )
-		goto _test_eof118;
-case 118:
-#line 1194 "ext/wikitext/wikitext_ragel.c"
-	if ( (*p) == 46u )
-		goto st17;
-	if ( (*p) < 65u ) {
-		if ( 48u <= (*p) && (*p) <= 57u )
-			goto st16;
-	} else if ( (*p) > 90u ) {
-		if ( 97u <= (*p) && (*p) <= 122u )
-			goto tr168;
-	} else
-		goto tr168;
-	goto tr166;
-tr168:
-#line 1 "NONE"
-	{te = p+1;}
-#line 304 "ext/wikitext/wikitext_ragel.rl"
-	{act = 22;}
-	goto st119;
-st119:
-	if ( ++p == pe )
-		goto _test_eof119;
-case 119:
-#line 1216 "ext/wikitext/wikitext_ragel.c"
-	if ( (*p) == 46u )
-		goto st17;
-	if ( (*p) < 65u ) {
-		if ( 48u <= (*p) && (*p) <= 57u )
-			goto st16;
-	} else if ( (*p) > 90u ) {
-		if ( 97u <= (*p) && (*p) <= 122u )
-			goto tr169;
-	} else
-		goto tr169;
-	goto tr166;
-tr169:
-#line 1 "NONE"
-	{te = p+1;}
-#line 304 "ext/wikitext/wikitext_ragel.rl"
+#line 310 "wikitext_ragel.rl"
 	{act = 22;}
 	goto st120;
 st120:
 	if ( ++p == pe )
 		goto _test_eof120;
 case 120:
-#line 1238 "ext/wikitext/wikitext_ragel.c"
+#line 1172 "wikitext_ragel.c"
+	if ( (*p) == 46u )
+		goto st17;
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st16;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
+			goto tr170;
+	} else
+		goto tr170;
+	goto tr169;
+tr170:
+#line 1 "NONE"
+	{te = p+1;}
+#line 310 "wikitext_ragel.rl"
+	{act = 22;}
+	goto st121;
+st121:
+	if ( ++p == pe )
+		goto _test_eof121;
+case 121:
+#line 1194 "wikitext_ragel.c"
+	if ( (*p) == 46u )
+		goto st17;
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st16;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
+			goto tr171;
+	} else
+		goto tr171;
+	goto tr169;
+tr171:
+#line 1 "NONE"
+	{te = p+1;}
+#line 310 "wikitext_ragel.rl"
+	{act = 22;}
+	goto st122;
+st122:
+	if ( ++p == pe )
+		goto _test_eof122;
+case 122:
+#line 1216 "wikitext_ragel.c"
+	if ( (*p) == 46u )
+		goto st17;
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st16;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
+			goto tr172;
+	} else
+		goto tr172;
+	goto tr169;
+tr172:
+#line 1 "NONE"
+	{te = p+1;}
+#line 310 "wikitext_ragel.rl"
+	{act = 22;}
+	goto st123;
+st123:
+	if ( ++p == pe )
+		goto _test_eof123;
+case 123:
+#line 1238 "wikitext_ragel.c"
 	if ( (*p) == 46u )
 		goto st17;
 	if ( (*p) < 65u ) {
@@ -1245,58 +1245,58 @@ case 120:
 			goto st16;
 	} else
 		goto st16;
-	goto tr166;
-tr165:
+	goto tr169;
+tr168:
 #line 1 "NONE"
 	{te = p+1;}
-#line 455 "ext/wikitext/wikitext_ragel.rl"
+#line 461 "wikitext_ragel.rl"
 	{act = 45;}
-	goto st121;
-st121:
+	goto st124;
+st124:
 	if ( ++p == pe )
-		goto _test_eof121;
-case 121:
-#line 1260 "ext/wikitext/wikitext_ragel.c"
+		goto _test_eof124;
+case 124:
+#line 1260 "wikitext_ragel.c"
 	switch( (*p) ) {
-		case 43u: goto st110;
-		case 45u: goto st110;
-		case 47u: goto st110;
-		case 64u: goto st110;
-		case 92u: goto st110;
-		case 126u: goto st110;
+		case 43u: goto st113;
+		case 45u: goto st113;
+		case 47u: goto st113;
+		case 64u: goto st113;
+		case 92u: goto st113;
+		case 126u: goto st113;
 	}
 	if ( (*p) < 65u ) {
 		if ( (*p) > 37u ) {
 			if ( 48u <= (*p) && (*p) <= 57u )
 				goto st16;
 		} else if ( (*p) >= 36u )
-			goto st110;
+			goto st113;
 	} else if ( (*p) > 90u ) {
 		if ( (*p) > 95u ) {
 			if ( 97u <= (*p) && (*p) <= 122u )
 				goto st16;
 		} else if ( (*p) >= 94u )
-			goto st110;
+			goto st113;
 	} else
 		goto st16;
-	goto tr155;
-tr131:
+	goto tr158;
+tr134:
 #line 1 "NONE"
 	{te = p+1;}
-#line 437 "ext/wikitext/wikitext_ragel.rl"
+#line 443 "wikitext_ragel.rl"
 	{act = 43;}
-	goto st122;
-st122:
+	goto st125;
+st125:
 	if ( ++p == pe )
-		goto _test_eof122;
-case 122:
-#line 1294 "ext/wikitext/wikitext_ragel.c"
+		goto _test_eof125;
+case 125:
+#line 1294 "wikitext_ragel.c"
 	switch( (*p) ) {
-		case 33u: goto st109;
-		case 44u: goto st109;
+		case 33u: goto st112;
+		case 44u: goto st112;
 		case 45u: goto st14;
-		case 46u: goto tr131;
-		case 63u: goto st109;
+		case 46u: goto tr134;
+		case 63u: goto st112;
 		case 64u: goto st15;
 		case 95u: goto st14;
 	}
@@ -1305,7 +1305,7 @@ case 122:
 			if ( 48u <= (*p) && (*p) <= 57u )
 				goto st14;
 		} else if ( (*p) >= 40u )
-			goto st109;
+			goto st112;
 	} else if ( (*p) > 59u ) {
 		if ( (*p) > 90u ) {
 			if ( 97u <= (*p) && (*p) <= 122u )
@@ -1313,106 +1313,106 @@ case 122:
 		} else if ( (*p) >= 65u )
 			goto st14;
 	} else
-		goto st109;
-	goto tr154;
-st123:
-	if ( ++p == pe )
-		goto _test_eof123;
-case 123:
-	switch( (*p) ) {
-		case 43u: goto st110;
-		case 45u: goto st124;
-		case 47u: goto st110;
-		case 64u: goto st110;
-		case 92u: goto st110;
-		case 94u: goto st110;
-		case 95u: goto st124;
-		case 126u: goto st110;
-	}
-	if ( (*p) < 46u ) {
-		if ( 36u <= (*p) && (*p) <= 37u )
-			goto st110;
-	} else if ( (*p) > 57u ) {
-		if ( (*p) > 90u ) {
-			if ( 97u <= (*p) && (*p) <= 122u )
-				goto st125;
-		} else if ( (*p) >= 65u )
-			goto st125;
-	} else
-		goto st125;
-	goto tr170;
-st124:
-	if ( ++p == pe )
-		goto _test_eof124;
-case 124:
-	switch( (*p) ) {
-		case 43u: goto st110;
-		case 45u: goto st124;
-		case 47u: goto st123;
-		case 64u: goto st110;
-		case 92u: goto st110;
-		case 94u: goto st110;
-		case 95u: goto st124;
-		case 126u: goto st110;
-	}
-	if ( (*p) < 46u ) {
-		if ( 36u <= (*p) && (*p) <= 37u )
-			goto st110;
-	} else if ( (*p) > 57u ) {
-		if ( (*p) > 90u ) {
-			if ( 97u <= (*p) && (*p) <= 122u )
-				goto st125;
-		} else if ( (*p) >= 65u )
-			goto st125;
-	} else
-		goto st125;
-	goto tr170;
-st125:
-	if ( ++p == pe )
-		goto _test_eof125;
-case 125:
-	switch( (*p) ) {
-		case 47u: goto st126;
-		case 95u: goto st125;
-	}
-	if ( (*p) < 65u ) {
-		if ( 45u <= (*p) && (*p) <= 57u )
-			goto st125;
-	} else if ( (*p) > 90u ) {
-		if ( 97u <= (*p) && (*p) <= 122u )
-			goto st125;
-	} else
-		goto st125;
-	goto tr170;
+		goto st112;
+	goto tr157;
 st126:
 	if ( ++p == pe )
 		goto _test_eof126;
 case 126:
-	if ( (*p) == 95u )
-		goto st125;
-	if ( (*p) < 48u ) {
-		if ( 45u <= (*p) && (*p) <= 46u )
-			goto st125;
+	switch( (*p) ) {
+		case 43u: goto st113;
+		case 45u: goto st127;
+		case 47u: goto st113;
+		case 64u: goto st113;
+		case 92u: goto st113;
+		case 94u: goto st113;
+		case 95u: goto st127;
+		case 126u: goto st113;
+	}
+	if ( (*p) < 46u ) {
+		if ( 36u <= (*p) && (*p) <= 37u )
+			goto st113;
 	} else if ( (*p) > 57u ) {
 		if ( (*p) > 90u ) {
 			if ( 97u <= (*p) && (*p) <= 122u )
-				goto st125;
+				goto st128;
 		} else if ( (*p) >= 65u )
-			goto st125;
+			goto st128;
 	} else
-		goto st125;
-	goto tr170;
-tr133:
-#line 1 "NONE"
-	{te = p+1;}
-#line 443 "ext/wikitext/wikitext_ragel.rl"
-	{act = 44;}
-	goto st127;
+		goto st128;
+	goto tr173;
 st127:
 	if ( ++p == pe )
 		goto _test_eof127;
 case 127:
-#line 1416 "ext/wikitext/wikitext_ragel.c"
+	switch( (*p) ) {
+		case 43u: goto st113;
+		case 45u: goto st127;
+		case 47u: goto st126;
+		case 64u: goto st113;
+		case 92u: goto st113;
+		case 94u: goto st113;
+		case 95u: goto st127;
+		case 126u: goto st113;
+	}
+	if ( (*p) < 46u ) {
+		if ( 36u <= (*p) && (*p) <= 37u )
+			goto st113;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto st128;
+		} else if ( (*p) >= 65u )
+			goto st128;
+	} else
+		goto st128;
+	goto tr173;
+st128:
+	if ( ++p == pe )
+		goto _test_eof128;
+case 128:
+	switch( (*p) ) {
+		case 47u: goto st129;
+		case 95u: goto st128;
+	}
+	if ( (*p) < 65u ) {
+		if ( 45u <= (*p) && (*p) <= 57u )
+			goto st128;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
+			goto st128;
+	} else
+		goto st128;
+	goto tr173;
+st129:
+	if ( ++p == pe )
+		goto _test_eof129;
+case 129:
+	if ( (*p) == 95u )
+		goto st128;
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st128;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto st128;
+		} else if ( (*p) >= 65u )
+			goto st128;
+	} else
+		goto st128;
+	goto tr173;
+tr136:
+#line 1 "NONE"
+	{te = p+1;}
+#line 449 "wikitext_ragel.rl"
+	{act = 44;}
+	goto st130;
+st130:
+	if ( ++p == pe )
+		goto _test_eof130;
+case 130:
+#line 1416 "wikitext_ragel.c"
 	switch( (*p) ) {
 		case 64u: goto st15;
 		case 95u: goto st14;
@@ -1423,21 +1423,21 @@ case 127:
 	} else if ( (*p) > 57u ) {
 		if ( (*p) > 90u ) {
 			if ( 97u <= (*p) && (*p) <= 122u )
-				goto tr133;
+				goto tr136;
 		} else if ( (*p) >= 65u )
-			goto tr133;
+			goto tr136;
 	} else
-		goto tr133;
-	goto tr174;
-tr134:
+		goto tr136;
+	goto tr177;
+tr137:
 #line 1 "NONE"
 	{te = p+1;}
-	goto st128;
-st128:
+	goto st131;
+st131:
 	if ( ++p == pe )
-		goto _test_eof128;
-case 128:
-#line 1441 "ext/wikitext/wikitext_ragel.c"
+		goto _test_eof131;
+case 131:
+#line 1441 "wikitext_ragel.c"
 	switch( (*p) ) {
 		case 47u: goto st19;
 		case 66u: goto st49;
@@ -1453,7 +1453,7 @@ case 128:
 		case 115u: goto st70;
 		case 116u: goto st76;
 	}
-	goto tr175;
+	goto tr178;
 st19:
 	if ( ++p == pe )
 		goto _test_eof19;
@@ -2069,112 +2069,112 @@ case 89:
 	if ( (*p) == 62u )
 		goto tr99;
 	goto tr23;
-tr135:
-#line 46 "ext/wikitext/wikitext_ragel.rl"
+tr138:
+#line 46 "wikitext_ragel.rl"
 	{
         MARK();
     }
-	goto st129;
-st129:
-	if ( ++p == pe )
-		goto _test_eof129;
-case 129:
-#line 2083 "ext/wikitext/wikitext_ragel.c"
-	switch( (*p) ) {
-		case 32u: goto st130;
-		case 61u: goto tr135;
-	}
-	goto tr184;
-st130:
-	if ( ++p == pe )
-		goto _test_eof130;
-case 130:
-	if ( (*p) == 32u )
-		goto st130;
-	goto tr184;
-tr136:
-#line 46 "ext/wikitext/wikitext_ragel.rl"
-	{
-        MARK();
-    }
-	goto st131;
-st131:
-	if ( ++p == pe )
-		goto _test_eof131;
-case 131:
-#line 2106 "ext/wikitext/wikitext_ragel.c"
-	if ( (*p) == 32u )
-		goto tr187;
-	goto tr186;
-tr137:
-#line 1 "NONE"
-	{te = p+1;}
-#line 443 "ext/wikitext/wikitext_ragel.rl"
-	{act = 44;}
 	goto st132;
 st132:
 	if ( ++p == pe )
 		goto _test_eof132;
 case 132:
-#line 2120 "ext/wikitext/wikitext_ragel.c"
+#line 2083 "wikitext_ragel.c"
 	switch( (*p) ) {
-		case 64u: goto st15;
-		case 84u: goto tr188;
-		case 95u: goto st14;
-		case 116u: goto tr188;
+		case 32u: goto st133;
+		case 61u: goto tr138;
 	}
-	if ( (*p) < 48u ) {
-		if ( 45u <= (*p) && (*p) <= 46u )
-			goto st14;
-	} else if ( (*p) > 57u ) {
-		if ( (*p) > 90u ) {
-			if ( 97u <= (*p) && (*p) <= 122u )
-				goto tr133;
-		} else if ( (*p) >= 65u )
-			goto tr133;
-	} else
-		goto tr133;
-	goto tr174;
-tr188:
-#line 1 "NONE"
-	{te = p+1;}
-#line 443 "ext/wikitext/wikitext_ragel.rl"
-	{act = 44;}
-	goto st133;
+	goto tr187;
 st133:
 	if ( ++p == pe )
 		goto _test_eof133;
 case 133:
-#line 2149 "ext/wikitext/wikitext_ragel.c"
-	switch( (*p) ) {
-		case 64u: goto st15;
-		case 80u: goto tr189;
-		case 95u: goto st14;
-		case 112u: goto tr189;
-	}
-	if ( (*p) < 48u ) {
-		if ( 45u <= (*p) && (*p) <= 46u )
-			goto st14;
-	} else if ( (*p) > 57u ) {
-		if ( (*p) > 90u ) {
-			if ( 97u <= (*p) && (*p) <= 122u )
-				goto tr133;
-		} else if ( (*p) >= 65u )
-			goto tr133;
-	} else
-		goto tr133;
-	goto tr174;
-tr189:
-#line 1 "NONE"
-	{te = p+1;}
-#line 443 "ext/wikitext/wikitext_ragel.rl"
-	{act = 44;}
+	if ( (*p) == 32u )
+		goto st133;
+	goto tr187;
+tr139:
+#line 46 "wikitext_ragel.rl"
+	{
+        MARK();
+    }
 	goto st134;
 st134:
 	if ( ++p == pe )
 		goto _test_eof134;
 case 134:
-#line 2178 "ext/wikitext/wikitext_ragel.c"
+#line 2106 "wikitext_ragel.c"
+	if ( (*p) == 32u )
+		goto tr190;
+	goto tr189;
+tr140:
+#line 1 "NONE"
+	{te = p+1;}
+#line 449 "wikitext_ragel.rl"
+	{act = 44;}
+	goto st135;
+st135:
+	if ( ++p == pe )
+		goto _test_eof135;
+case 135:
+#line 2120 "wikitext_ragel.c"
+	switch( (*p) ) {
+		case 64u: goto st15;
+		case 84u: goto tr191;
+		case 95u: goto st14;
+		case 116u: goto tr191;
+	}
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st14;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto tr136;
+		} else if ( (*p) >= 65u )
+			goto tr136;
+	} else
+		goto tr136;
+	goto tr177;
+tr191:
+#line 1 "NONE"
+	{te = p+1;}
+#line 449 "wikitext_ragel.rl"
+	{act = 44;}
+	goto st136;
+st136:
+	if ( ++p == pe )
+		goto _test_eof136;
+case 136:
+#line 2149 "wikitext_ragel.c"
+	switch( (*p) ) {
+		case 64u: goto st15;
+		case 80u: goto tr192;
+		case 95u: goto st14;
+		case 112u: goto tr192;
+	}
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st14;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto tr136;
+		} else if ( (*p) >= 65u )
+			goto tr136;
+	} else
+		goto tr136;
+	goto tr177;
+tr192:
+#line 1 "NONE"
+	{te = p+1;}
+#line 449 "wikitext_ragel.rl"
+	{act = 44;}
+	goto st137;
+st137:
+	if ( ++p == pe )
+		goto _test_eof137;
+case 137:
+#line 2178 "wikitext_ragel.c"
 	switch( (*p) ) {
 		case 58u: goto st90;
 		case 64u: goto st15;
@@ -2186,12 +2186,12 @@ case 134:
 	} else if ( (*p) > 57u ) {
 		if ( (*p) > 90u ) {
 			if ( 97u <= (*p) && (*p) <= 122u )
-				goto tr133;
+				goto tr136;
 		} else if ( (*p) >= 65u )
-			goto tr133;
+			goto tr136;
 	} else
-		goto tr133;
-	goto tr174;
+		goto tr136;
+	goto tr177;
 st90:
 	if ( ++p == pe )
 		goto _test_eof90;
@@ -2216,30 +2216,41 @@ case 92:
 		case 95u: goto tr103;
 		case 126u: goto tr103;
 	}
-	if ( (*p) < 47u ) {
-		if ( (*p) > 40u ) {
-			if ( 42u <= (*p) && (*p) <= 43u )
+	if ( (*p) < 64u ) {
+		if ( (*p) < 42u ) {
+			if ( 35u <= (*p) && (*p) <= 40u )
 				goto tr103;
-		} else if ( (*p) >= 35u )
+		} else if ( (*p) > 43u ) {
+			if ( 47u <= (*p) && (*p) <= 57u )
+				goto tr103;
+		} else
 			goto tr103;
-	} else if ( (*p) > 57u ) {
-		if ( (*p) > 90u ) {
+	} else if ( (*p) > 90u ) {
+		if ( (*p) < 194u ) {
 			if ( 97u <= (*p) && (*p) <= 122u )
 				goto tr103;
-		} else if ( (*p) >= 64u )
-			goto tr103;
+		} else if ( (*p) > 223u ) {
+			if ( (*p) > 239u ) {
+				if ( 240u <= (*p) && (*p) <= 244u )
+					goto st96;
+			} else if ( (*p) >= 224u )
+				goto st95;
+		} else
+			goto st94;
 	} else
 		goto tr103;
 	goto tr100;
 tr103:
 #line 1 "NONE"
 	{te = p+1;}
-	goto st135;
-st135:
+#line 304 "wikitext_ragel.rl"
+	{act = 21;}
+	goto st138;
+st138:
 	if ( ++p == pe )
-		goto _test_eof135;
-case 135:
-#line 2243 "ext/wikitext/wikitext_ragel.c"
+		goto _test_eof138;
+case 138:
+#line 2254 "wikitext_ragel.c"
 	switch( (*p) ) {
 		case 33u: goto st93;
 		case 41u: goto st93;
@@ -2250,18 +2261,27 @@ case 135:
 		case 95u: goto tr103;
 		case 126u: goto tr103;
 	}
-	if ( (*p) < 58u ) {
-		if ( 35u <= (*p) && (*p) <= 57u )
-			goto tr103;
-	} else if ( (*p) > 59u ) {
-		if ( (*p) > 90u ) {
-			if ( 97u <= (*p) && (*p) <= 122u )
+	if ( (*p) < 97u ) {
+		if ( (*p) < 58u ) {
+			if ( 35u <= (*p) && (*p) <= 57u )
 				goto tr103;
-		} else if ( (*p) >= 64u )
-			goto tr103;
+		} else if ( (*p) > 59u ) {
+			if ( 64u <= (*p) && (*p) <= 90u )
+				goto tr103;
+		} else
+			goto st93;
+	} else if ( (*p) > 122u ) {
+		if ( (*p) < 224u ) {
+			if ( 194u <= (*p) && (*p) <= 223u )
+				goto st94;
+		} else if ( (*p) > 239u ) {
+			if ( 240u <= (*p) && (*p) <= 244u )
+				goto st96;
+		} else
+			goto st95;
 	} else
-		goto st93;
-	goto tr191;
+		goto tr103;
+	goto tr194;
 st93:
 	if ( ++p == pe )
 		goto _test_eof93;
@@ -2276,122 +2296,64 @@ case 93:
 		case 95u: goto tr103;
 		case 126u: goto tr103;
 	}
-	if ( (*p) < 58u ) {
-		if ( 35u <= (*p) && (*p) <= 57u )
-			goto tr103;
-	} else if ( (*p) > 59u ) {
-		if ( (*p) > 90u ) {
-			if ( 97u <= (*p) && (*p) <= 122u )
+	if ( (*p) < 97u ) {
+		if ( (*p) < 58u ) {
+			if ( 35u <= (*p) && (*p) <= 57u )
 				goto tr103;
-		} else if ( (*p) >= 64u )
-			goto tr103;
+		} else if ( (*p) > 59u ) {
+			if ( 64u <= (*p) && (*p) <= 90u )
+				goto tr103;
+		} else
+			goto st93;
+	} else if ( (*p) > 122u ) {
+		if ( (*p) < 224u ) {
+			if ( 194u <= (*p) && (*p) <= 223u )
+				goto st94;
+		} else if ( (*p) > 239u ) {
+			if ( 240u <= (*p) && (*p) <= 244u )
+				goto st96;
+		} else
+			goto st95;
 	} else
-		goto st93;
-	goto tr104;
-tr138:
-#line 1 "NONE"
-	{te = p+1;}
-#line 443 "ext/wikitext/wikitext_ragel.rl"
-	{act = 44;}
-	goto st136;
-st136:
+		goto tr103;
+	goto tr107;
+st94:
 	if ( ++p == pe )
-		goto _test_eof136;
-case 136:
-#line 2302 "ext/wikitext/wikitext_ragel.c"
-	switch( (*p) ) {
-		case 64u: goto st15;
-		case 84u: goto tr192;
-		case 95u: goto st14;
-		case 116u: goto tr192;
-	}
-	if ( (*p) < 48u ) {
-		if ( 45u <= (*p) && (*p) <= 46u )
-			goto st14;
-	} else if ( (*p) > 57u ) {
-		if ( (*p) > 90u ) {
-			if ( 97u <= (*p) && (*p) <= 122u )
-				goto tr133;
-		} else if ( (*p) >= 65u )
-			goto tr133;
-	} else
-		goto tr133;
-	goto tr174;
-tr192:
-#line 1 "NONE"
-	{te = p+1;}
-#line 443 "ext/wikitext/wikitext_ragel.rl"
-	{act = 44;}
-	goto st137;
-st137:
+		goto _test_eof94;
+case 94:
+	if ( 128u <= (*p) && (*p) <= 191u )
+		goto tr103;
+	goto tr16;
+st95:
 	if ( ++p == pe )
-		goto _test_eof137;
-case 137:
-#line 2331 "ext/wikitext/wikitext_ragel.c"
-	switch( (*p) ) {
-		case 64u: goto st15;
-		case 84u: goto tr193;
-		case 95u: goto st14;
-		case 116u: goto tr193;
-	}
-	if ( (*p) < 48u ) {
-		if ( 45u <= (*p) && (*p) <= 46u )
-			goto st14;
-	} else if ( (*p) > 57u ) {
-		if ( (*p) > 90u ) {
-			if ( 97u <= (*p) && (*p) <= 122u )
-				goto tr133;
-		} else if ( (*p) >= 65u )
-			goto tr133;
-	} else
-		goto tr133;
-	goto tr174;
-tr193:
-#line 1 "NONE"
-	{te = p+1;}
-#line 443 "ext/wikitext/wikitext_ragel.rl"
-	{act = 44;}
-	goto st138;
-st138:
+		goto _test_eof95;
+case 95:
+	if ( 128u <= (*p) && (*p) <= 191u )
+		goto st94;
+	goto tr16;
+st96:
 	if ( ++p == pe )
-		goto _test_eof138;
-case 138:
-#line 2360 "ext/wikitext/wikitext_ragel.c"
-	switch( (*p) ) {
-		case 64u: goto st15;
-		case 80u: goto tr194;
-		case 95u: goto st14;
-		case 112u: goto tr194;
-	}
-	if ( (*p) < 48u ) {
-		if ( 45u <= (*p) && (*p) <= 46u )
-			goto st14;
-	} else if ( (*p) > 57u ) {
-		if ( (*p) > 90u ) {
-			if ( 97u <= (*p) && (*p) <= 122u )
-				goto tr133;
-		} else if ( (*p) >= 65u )
-			goto tr133;
-	} else
-		goto tr133;
-	goto tr174;
-tr194:
+		goto _test_eof96;
+case 96:
+	if ( 128u <= (*p) && (*p) <= 191u )
+		goto st95;
+	goto tr16;
+tr141:
 #line 1 "NONE"
 	{te = p+1;}
-#line 443 "ext/wikitext/wikitext_ragel.rl"
+#line 449 "wikitext_ragel.rl"
 	{act = 44;}
 	goto st139;
 st139:
 	if ( ++p == pe )
 		goto _test_eof139;
 case 139:
-#line 2389 "ext/wikitext/wikitext_ragel.c"
+#line 2352 "wikitext_ragel.c"
 	switch( (*p) ) {
-		case 58u: goto st90;
 		case 64u: goto st15;
-		case 83u: goto tr189;
+		case 84u: goto tr195;
 		case 95u: goto st14;
-		case 115u: goto tr189;
+		case 116u: goto tr195;
 	}
 	if ( (*p) < 48u ) {
 		if ( 45u <= (*p) && (*p) <= 46u )
@@ -2399,28 +2361,116 @@ case 139:
 	} else if ( (*p) > 57u ) {
 		if ( (*p) > 90u ) {
 			if ( 97u <= (*p) && (*p) <= 122u )
-				goto tr133;
+				goto tr136;
 		} else if ( (*p) >= 65u )
-			goto tr133;
+			goto tr136;
 	} else
-		goto tr133;
-	goto tr174;
-tr139:
+		goto tr136;
+	goto tr177;
+tr195:
 #line 1 "NONE"
 	{te = p+1;}
-#line 443 "ext/wikitext/wikitext_ragel.rl"
+#line 449 "wikitext_ragel.rl"
 	{act = 44;}
 	goto st140;
 st140:
 	if ( ++p == pe )
 		goto _test_eof140;
 case 140:
-#line 2419 "ext/wikitext/wikitext_ragel.c"
+#line 2381 "wikitext_ragel.c"
 	switch( (*p) ) {
 		case 64u: goto st15;
-		case 65u: goto tr195;
+		case 84u: goto tr196;
 		case 95u: goto st14;
-		case 97u: goto tr195;
+		case 116u: goto tr196;
+	}
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st14;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto tr136;
+		} else if ( (*p) >= 65u )
+			goto tr136;
+	} else
+		goto tr136;
+	goto tr177;
+tr196:
+#line 1 "NONE"
+	{te = p+1;}
+#line 449 "wikitext_ragel.rl"
+	{act = 44;}
+	goto st141;
+st141:
+	if ( ++p == pe )
+		goto _test_eof141;
+case 141:
+#line 2410 "wikitext_ragel.c"
+	switch( (*p) ) {
+		case 64u: goto st15;
+		case 80u: goto tr197;
+		case 95u: goto st14;
+		case 112u: goto tr197;
+	}
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st14;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto tr136;
+		} else if ( (*p) >= 65u )
+			goto tr136;
+	} else
+		goto tr136;
+	goto tr177;
+tr197:
+#line 1 "NONE"
+	{te = p+1;}
+#line 449 "wikitext_ragel.rl"
+	{act = 44;}
+	goto st142;
+st142:
+	if ( ++p == pe )
+		goto _test_eof142;
+case 142:
+#line 2439 "wikitext_ragel.c"
+	switch( (*p) ) {
+		case 58u: goto st90;
+		case 64u: goto st15;
+		case 83u: goto tr192;
+		case 95u: goto st14;
+		case 115u: goto tr192;
+	}
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st14;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto tr136;
+		} else if ( (*p) >= 65u )
+			goto tr136;
+	} else
+		goto tr136;
+	goto tr177;
+tr142:
+#line 1 "NONE"
+	{te = p+1;}
+#line 449 "wikitext_ragel.rl"
+	{act = 44;}
+	goto st143;
+st143:
+	if ( ++p == pe )
+		goto _test_eof143;
+case 143:
+#line 2469 "wikitext_ragel.c"
+	switch( (*p) ) {
+		case 64u: goto st15;
+		case 65u: goto tr198;
+		case 95u: goto st14;
+		case 97u: goto tr198;
 	}
 	if ( (*p) < 48u ) {
 		if ( 45u <= (*p) && (*p) <= 46u )
@@ -2428,115 +2478,28 @@ case 140:
 	} else if ( (*p) > 57u ) {
 		if ( (*p) > 90u ) {
 			if ( 98u <= (*p) && (*p) <= 122u )
-				goto tr133;
+				goto tr136;
 		} else if ( (*p) >= 66u )
-			goto tr133;
+			goto tr136;
 	} else
-		goto tr133;
-	goto tr174;
-tr195:
-#line 1 "NONE"
-	{te = p+1;}
-#line 443 "ext/wikitext/wikitext_ragel.rl"
-	{act = 44;}
-	goto st141;
-st141:
-	if ( ++p == pe )
-		goto _test_eof141;
-case 141:
-#line 2448 "ext/wikitext/wikitext_ragel.c"
-	switch( (*p) ) {
-		case 64u: goto st15;
-		case 73u: goto tr196;
-		case 95u: goto st14;
-		case 105u: goto tr196;
-	}
-	if ( (*p) < 48u ) {
-		if ( 45u <= (*p) && (*p) <= 46u )
-			goto st14;
-	} else if ( (*p) > 57u ) {
-		if ( (*p) > 90u ) {
-			if ( 97u <= (*p) && (*p) <= 122u )
-				goto tr133;
-		} else if ( (*p) >= 65u )
-			goto tr133;
-	} else
-		goto tr133;
-	goto tr174;
-tr196:
-#line 1 "NONE"
-	{te = p+1;}
-#line 443 "ext/wikitext/wikitext_ragel.rl"
-	{act = 44;}
-	goto st142;
-st142:
-	if ( ++p == pe )
-		goto _test_eof142;
-case 142:
-#line 2477 "ext/wikitext/wikitext_ragel.c"
-	switch( (*p) ) {
-		case 64u: goto st15;
-		case 76u: goto tr197;
-		case 95u: goto st14;
-		case 108u: goto tr197;
-	}
-	if ( (*p) < 48u ) {
-		if ( 45u <= (*p) && (*p) <= 46u )
-			goto st14;
-	} else if ( (*p) > 57u ) {
-		if ( (*p) > 90u ) {
-			if ( 97u <= (*p) && (*p) <= 122u )
-				goto tr133;
-		} else if ( (*p) >= 65u )
-			goto tr133;
-	} else
-		goto tr133;
-	goto tr174;
-tr197:
-#line 1 "NONE"
-	{te = p+1;}
-#line 443 "ext/wikitext/wikitext_ragel.rl"
-	{act = 44;}
-	goto st143;
-st143:
-	if ( ++p == pe )
-		goto _test_eof143;
-case 143:
-#line 2506 "ext/wikitext/wikitext_ragel.c"
-	switch( (*p) ) {
-		case 64u: goto st15;
-		case 84u: goto tr198;
-		case 95u: goto st14;
-		case 116u: goto tr198;
-	}
-	if ( (*p) < 48u ) {
-		if ( 45u <= (*p) && (*p) <= 46u )
-			goto st14;
-	} else if ( (*p) > 57u ) {
-		if ( (*p) > 90u ) {
-			if ( 97u <= (*p) && (*p) <= 122u )
-				goto tr133;
-		} else if ( (*p) >= 65u )
-			goto tr133;
-	} else
-		goto tr133;
-	goto tr174;
+		goto tr136;
+	goto tr177;
 tr198:
 #line 1 "NONE"
 	{te = p+1;}
-#line 443 "ext/wikitext/wikitext_ragel.rl"
+#line 449 "wikitext_ragel.rl"
 	{act = 44;}
 	goto st144;
 st144:
 	if ( ++p == pe )
 		goto _test_eof144;
 case 144:
-#line 2535 "ext/wikitext/wikitext_ragel.c"
+#line 2498 "wikitext_ragel.c"
 	switch( (*p) ) {
 		case 64u: goto st15;
-		case 79u: goto tr199;
+		case 73u: goto tr199;
 		case 95u: goto st14;
-		case 111u: goto tr199;
+		case 105u: goto tr199;
 	}
 	if ( (*p) < 48u ) {
 		if ( 45u <= (*p) && (*p) <= 46u )
@@ -2544,25 +2507,112 @@ case 144:
 	} else if ( (*p) > 57u ) {
 		if ( (*p) > 90u ) {
 			if ( 97u <= (*p) && (*p) <= 122u )
-				goto tr133;
+				goto tr136;
 		} else if ( (*p) >= 65u )
-			goto tr133;
+			goto tr136;
 	} else
-		goto tr133;
-	goto tr174;
+		goto tr136;
+	goto tr177;
 tr199:
 #line 1 "NONE"
 	{te = p+1;}
-#line 443 "ext/wikitext/wikitext_ragel.rl"
+#line 449 "wikitext_ragel.rl"
 	{act = 44;}
 	goto st145;
 st145:
 	if ( ++p == pe )
 		goto _test_eof145;
 case 145:
-#line 2564 "ext/wikitext/wikitext_ragel.c"
+#line 2527 "wikitext_ragel.c"
 	switch( (*p) ) {
-		case 58u: goto st94;
+		case 64u: goto st15;
+		case 76u: goto tr200;
+		case 95u: goto st14;
+		case 108u: goto tr200;
+	}
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st14;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto tr136;
+		} else if ( (*p) >= 65u )
+			goto tr136;
+	} else
+		goto tr136;
+	goto tr177;
+tr200:
+#line 1 "NONE"
+	{te = p+1;}
+#line 449 "wikitext_ragel.rl"
+	{act = 44;}
+	goto st146;
+st146:
+	if ( ++p == pe )
+		goto _test_eof146;
+case 146:
+#line 2556 "wikitext_ragel.c"
+	switch( (*p) ) {
+		case 64u: goto st15;
+		case 84u: goto tr201;
+		case 95u: goto st14;
+		case 116u: goto tr201;
+	}
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st14;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto tr136;
+		} else if ( (*p) >= 65u )
+			goto tr136;
+	} else
+		goto tr136;
+	goto tr177;
+tr201:
+#line 1 "NONE"
+	{te = p+1;}
+#line 449 "wikitext_ragel.rl"
+	{act = 44;}
+	goto st147;
+st147:
+	if ( ++p == pe )
+		goto _test_eof147;
+case 147:
+#line 2585 "wikitext_ragel.c"
+	switch( (*p) ) {
+		case 64u: goto st15;
+		case 79u: goto tr202;
+		case 95u: goto st14;
+		case 111u: goto tr202;
+	}
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st14;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto tr136;
+		} else if ( (*p) >= 65u )
+			goto tr136;
+	} else
+		goto tr136;
+	goto tr177;
+tr202:
+#line 1 "NONE"
+	{te = p+1;}
+#line 449 "wikitext_ragel.rl"
+	{act = 44;}
+	goto st148;
+st148:
+	if ( ++p == pe )
+		goto _test_eof148;
+case 148:
+#line 2614 "wikitext_ragel.c"
+	switch( (*p) ) {
+		case 58u: goto st97;
 		case 64u: goto st15;
 		case 95u: goto st14;
 	}
@@ -2572,239 +2622,210 @@ case 145:
 	} else if ( (*p) > 57u ) {
 		if ( (*p) > 90u ) {
 			if ( 97u <= (*p) && (*p) <= 122u )
-				goto tr133;
+				goto tr136;
 		} else if ( (*p) >= 65u )
-			goto tr133;
+			goto tr136;
 	} else
-		goto tr133;
-	goto tr174;
-st94:
-	if ( ++p == pe )
-		goto _test_eof94;
-case 94:
-	if ( (*p) == 95u )
-		goto st95;
-	if ( (*p) < 48u ) {
-		if ( 45u <= (*p) && (*p) <= 46u )
-			goto st95;
-	} else if ( (*p) > 57u ) {
-		if ( (*p) > 90u ) {
-			if ( 97u <= (*p) && (*p) <= 122u )
-				goto st95;
-		} else if ( (*p) >= 65u )
-			goto st95;
-	} else
-		goto st95;
-	goto tr100;
-st95:
-	if ( ++p == pe )
-		goto _test_eof95;
-case 95:
-	switch( (*p) ) {
-		case 64u: goto st96;
-		case 95u: goto st95;
-	}
-	if ( (*p) < 48u ) {
-		if ( 45u <= (*p) && (*p) <= 46u )
-			goto st95;
-	} else if ( (*p) > 57u ) {
-		if ( (*p) > 90u ) {
-			if ( 97u <= (*p) && (*p) <= 122u )
-				goto st95;
-		} else if ( (*p) >= 65u )
-			goto st95;
-	} else
-		goto st95;
-	goto tr100;
-st96:
-	if ( ++p == pe )
-		goto _test_eof96;
-case 96:
-	if ( (*p) < 65u ) {
-		if ( 48u <= (*p) && (*p) <= 57u )
-			goto st97;
-	} else if ( (*p) > 90u ) {
-		if ( 97u <= (*p) && (*p) <= 122u )
-			goto st97;
-	} else
-		goto st97;
-	goto tr100;
+		goto tr136;
+	goto tr177;
 st97:
 	if ( ++p == pe )
 		goto _test_eof97;
 case 97:
-	if ( (*p) == 46u )
+	if ( (*p) == 95u )
 		goto st98;
-	if ( (*p) < 65u ) {
-		if ( 48u <= (*p) && (*p) <= 57u )
-			goto st97;
-	} else if ( (*p) > 90u ) {
-		if ( 97u <= (*p) && (*p) <= 122u )
-			goto st97;
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st98;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto st98;
+		} else if ( (*p) >= 65u )
+			goto st98;
 	} else
-		goto st97;
-	goto tr16;
+		goto st98;
+	goto tr100;
 st98:
 	if ( ++p == pe )
 		goto _test_eof98;
 case 98:
-	if ( (*p) < 65u ) {
-		if ( 48u <= (*p) && (*p) <= 57u )
-			goto st97;
-	} else if ( (*p) > 90u ) {
-		if ( 97u <= (*p) && (*p) <= 122u )
-			goto st99;
+	switch( (*p) ) {
+		case 64u: goto st99;
+		case 95u: goto st98;
+	}
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st98;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto st98;
+		} else if ( (*p) >= 65u )
+			goto st98;
 	} else
-		goto st99;
-	goto tr16;
+		goto st98;
+	goto tr100;
 st99:
 	if ( ++p == pe )
 		goto _test_eof99;
 case 99:
-	if ( (*p) == 46u )
-		goto st98;
 	if ( (*p) < 65u ) {
 		if ( 48u <= (*p) && (*p) <= 57u )
-			goto st97;
+			goto st100;
 	} else if ( (*p) > 90u ) {
 		if ( 97u <= (*p) && (*p) <= 122u )
-			goto tr111;
+			goto st100;
 	} else
-		goto tr111;
+		goto st100;
+	goto tr100;
+st100:
+	if ( ++p == pe )
+		goto _test_eof100;
+case 100:
+	if ( (*p) == 46u )
+		goto st101;
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st100;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
+			goto st100;
+	} else
+		goto st100;
 	goto tr16;
-tr111:
-#line 1 "NONE"
-	{te = p+1;}
-#line 298 "ext/wikitext/wikitext_ragel.rl"
-	{act = 21;}
-	goto st146;
-st146:
+st101:
 	if ( ++p == pe )
-		goto _test_eof146;
-case 146:
-#line 2686 "ext/wikitext/wikitext_ragel.c"
-	if ( (*p) == 46u )
-		goto st98;
+		goto _test_eof101;
+case 101:
 	if ( (*p) < 65u ) {
 		if ( 48u <= (*p) && (*p) <= 57u )
-			goto st97;
+			goto st100;
 	} else if ( (*p) > 90u ) {
 		if ( 97u <= (*p) && (*p) <= 122u )
-			goto tr201;
+			goto st102;
 	} else
-		goto tr201;
-	goto tr191;
-tr201:
-#line 1 "NONE"
-	{te = p+1;}
-#line 298 "ext/wikitext/wikitext_ragel.rl"
-	{act = 21;}
-	goto st147;
-st147:
+		goto st102;
+	goto tr16;
+st102:
 	if ( ++p == pe )
-		goto _test_eof147;
-case 147:
-#line 2708 "ext/wikitext/wikitext_ragel.c"
+		goto _test_eof102;
+case 102:
 	if ( (*p) == 46u )
-		goto st98;
+		goto st101;
 	if ( (*p) < 65u ) {
 		if ( 48u <= (*p) && (*p) <= 57u )
-			goto st97;
+			goto st100;
 	} else if ( (*p) > 90u ) {
 		if ( 97u <= (*p) && (*p) <= 122u )
-			goto tr202;
+			goto tr114;
 	} else
-		goto tr202;
-	goto tr191;
-tr202:
+		goto tr114;
+	goto tr16;
+tr114:
 #line 1 "NONE"
 	{te = p+1;}
-#line 298 "ext/wikitext/wikitext_ragel.rl"
-	{act = 21;}
-	goto st148;
-st148:
-	if ( ++p == pe )
-		goto _test_eof148;
-case 148:
-#line 2730 "ext/wikitext/wikitext_ragel.c"
-	if ( (*p) == 46u )
-		goto st98;
-	if ( (*p) < 65u ) {
-		if ( 48u <= (*p) && (*p) <= 57u )
-			goto st97;
-	} else if ( (*p) > 90u ) {
-		if ( 97u <= (*p) && (*p) <= 122u )
-			goto tr203;
-	} else
-		goto tr203;
-	goto tr191;
-tr203:
-#line 1 "NONE"
-	{te = p+1;}
-#line 298 "ext/wikitext/wikitext_ragel.rl"
+#line 304 "wikitext_ragel.rl"
 	{act = 21;}
 	goto st149;
 st149:
 	if ( ++p == pe )
 		goto _test_eof149;
 case 149:
-#line 2752 "ext/wikitext/wikitext_ragel.c"
+#line 2736 "wikitext_ragel.c"
 	if ( (*p) == 46u )
-		goto st98;
+		goto st101;
 	if ( (*p) < 65u ) {
 		if ( 48u <= (*p) && (*p) <= 57u )
-			goto st97;
+			goto st100;
 	} else if ( (*p) > 90u ) {
 		if ( 97u <= (*p) && (*p) <= 122u )
-			goto st97;
+			goto tr204;
 	} else
-		goto st97;
-	goto tr191;
-tr140:
+		goto tr204;
+	goto tr194;
+tr204:
 #line 1 "NONE"
 	{te = p+1;}
-#line 443 "ext/wikitext/wikitext_ragel.rl"
-	{act = 44;}
+#line 304 "wikitext_ragel.rl"
+	{act = 21;}
 	goto st150;
 st150:
 	if ( ++p == pe )
 		goto _test_eof150;
 case 150:
-#line 2774 "ext/wikitext/wikitext_ragel.c"
-	switch( (*p) ) {
-		case 64u: goto st15;
-		case 86u: goto tr204;
-		case 95u: goto st14;
-		case 118u: goto tr204;
-	}
-	if ( (*p) < 48u ) {
-		if ( 45u <= (*p) && (*p) <= 46u )
-			goto st14;
-	} else if ( (*p) > 57u ) {
-		if ( (*p) > 90u ) {
-			if ( 97u <= (*p) && (*p) <= 122u )
-				goto tr133;
-		} else if ( (*p) >= 65u )
-			goto tr133;
+#line 2758 "wikitext_ragel.c"
+	if ( (*p) == 46u )
+		goto st101;
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st100;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
+			goto tr205;
 	} else
-		goto tr133;
-	goto tr174;
-tr204:
+		goto tr205;
+	goto tr194;
+tr205:
 #line 1 "NONE"
 	{te = p+1;}
-#line 443 "ext/wikitext/wikitext_ragel.rl"
-	{act = 44;}
+#line 304 "wikitext_ragel.rl"
+	{act = 21;}
 	goto st151;
 st151:
 	if ( ++p == pe )
 		goto _test_eof151;
 case 151:
-#line 2803 "ext/wikitext/wikitext_ragel.c"
+#line 2780 "wikitext_ragel.c"
+	if ( (*p) == 46u )
+		goto st101;
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st100;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
+			goto tr206;
+	} else
+		goto tr206;
+	goto tr194;
+tr206:
+#line 1 "NONE"
+	{te = p+1;}
+#line 304 "wikitext_ragel.rl"
+	{act = 21;}
+	goto st152;
+st152:
+	if ( ++p == pe )
+		goto _test_eof152;
+case 152:
+#line 2802 "wikitext_ragel.c"
+	if ( (*p) == 46u )
+		goto st101;
+	if ( (*p) < 65u ) {
+		if ( 48u <= (*p) && (*p) <= 57u )
+			goto st100;
+	} else if ( (*p) > 90u ) {
+		if ( 97u <= (*p) && (*p) <= 122u )
+			goto st100;
+	} else
+		goto st100;
+	goto tr194;
+tr143:
+#line 1 "NONE"
+	{te = p+1;}
+#line 449 "wikitext_ragel.rl"
+	{act = 44;}
+	goto st153;
+st153:
+	if ( ++p == pe )
+		goto _test_eof153;
+case 153:
+#line 2824 "wikitext_ragel.c"
 	switch( (*p) ) {
 		case 64u: goto st15;
-		case 78u: goto tr189;
+		case 86u: goto tr207;
 		case 95u: goto st14;
-		case 110u: goto tr189;
+		case 118u: goto tr207;
 	}
 	if ( (*p) < 48u ) {
 		if ( 45u <= (*p) && (*p) <= 46u )
@@ -2812,67 +2833,75 @@ case 151:
 	} else if ( (*p) > 57u ) {
 		if ( (*p) > 90u ) {
 			if ( 97u <= (*p) && (*p) <= 122u )
-				goto tr133;
+				goto tr136;
 		} else if ( (*p) >= 65u )
-			goto tr133;
+			goto tr136;
 	} else
-		goto tr133;
-	goto tr174;
-st152:
-	if ( ++p == pe )
-		goto _test_eof152;
-case 152:
-	if ( (*p) == 91u )
-		goto tr206;
-	goto tr205;
-st153:
-	if ( ++p == pe )
-		goto _test_eof153;
-case 153:
-	if ( (*p) == 93u )
-		goto tr208;
-	goto tr207;
+		goto tr136;
+	goto tr177;
+tr207:
+#line 1 "NONE"
+	{te = p+1;}
+#line 449 "wikitext_ragel.rl"
+	{act = 44;}
+	goto st154;
 st154:
 	if ( ++p == pe )
 		goto _test_eof154;
 case 154:
-	if ( (*p) == 123u )
-		goto tr210;
-	goto tr209;
+#line 2853 "wikitext_ragel.c"
+	switch( (*p) ) {
+		case 64u: goto st15;
+		case 78u: goto tr192;
+		case 95u: goto st14;
+		case 110u: goto tr192;
+	}
+	if ( (*p) < 48u ) {
+		if ( 45u <= (*p) && (*p) <= 46u )
+			goto st14;
+	} else if ( (*p) > 57u ) {
+		if ( (*p) > 90u ) {
+			if ( 97u <= (*p) && (*p) <= 122u )
+				goto tr136;
+		} else if ( (*p) >= 65u )
+			goto tr136;
+	} else
+		goto tr136;
+	goto tr177;
 st155:
 	if ( ++p == pe )
 		goto _test_eof155;
 case 155:
+	if ( (*p) == 91u )
+		goto tr209;
+	goto tr208;
+st156:
+	if ( ++p == pe )
+		goto _test_eof156;
+case 156:
+	if ( (*p) == 93u )
+		goto tr211;
+	goto tr210;
+st157:
+	if ( ++p == pe )
+		goto _test_eof157;
+case 157:
+	if ( (*p) == 123u )
+		goto tr213;
+	goto tr212;
+st158:
+	if ( ++p == pe )
+		goto _test_eof158;
+case 158:
 	if ( (*p) == 125u )
-		goto tr212;
-	goto tr211;
-st100:
-	if ( ++p == pe )
-		goto _test_eof100;
-case 100:
-	if ( 128u <= (*p) && (*p) <= 191u )
-		goto tr112;
-	goto st0;
-st101:
-	if ( ++p == pe )
-		goto _test_eof101;
-case 101:
-	if ( 128u <= (*p) && (*p) <= 191u )
-		goto st102;
-	goto st0;
-st102:
-	if ( ++p == pe )
-		goto _test_eof102;
-case 102:
-	if ( 128u <= (*p) && (*p) <= 191u )
-		goto tr115;
-	goto st0;
+		goto tr215;
+	goto tr214;
 st103:
 	if ( ++p == pe )
 		goto _test_eof103;
 case 103:
 	if ( 128u <= (*p) && (*p) <= 191u )
-		goto st104;
+		goto tr115;
 	goto st0;
 st104:
 	if ( ++p == pe )
@@ -2888,172 +2917,196 @@ case 105:
 	if ( 128u <= (*p) && (*p) <= 191u )
 		goto tr118;
 	goto st0;
+st106:
+	if ( ++p == pe )
+		goto _test_eof106;
+case 106:
+	if ( 128u <= (*p) && (*p) <= 191u )
+		goto st107;
+	goto st0;
+st107:
+	if ( ++p == pe )
+		goto _test_eof107;
+case 107:
+	if ( 128u <= (*p) && (*p) <= 191u )
+		goto st108;
+	goto st0;
+st108:
+	if ( ++p == pe )
+		goto _test_eof108;
+case 108:
+	if ( 128u <= (*p) && (*p) <= 191u )
+		goto tr121;
+	goto st0;
 	}
-	_test_eof106: cs = 106; goto _test_eof; 
-	_test_eof107: cs = 107; goto _test_eof; 
-	_test_eof108: cs = 108; goto _test_eof; 
-	_test_eof109: cs = 109; goto _test_eof; 
-	_test_eof110: cs = 110; goto _test_eof; 
-	_test_eof111: cs = 111; goto _test_eof; 
-	_test_eof1: cs = 1; goto _test_eof; 
-	_test_eof2: cs = 2; goto _test_eof; 
-	_test_eof3: cs = 3; goto _test_eof; 
-	_test_eof4: cs = 4; goto _test_eof; 
-	_test_eof5: cs = 5; goto _test_eof; 
-	_test_eof6: cs = 6; goto _test_eof; 
-	_test_eof7: cs = 7; goto _test_eof; 
-	_test_eof8: cs = 8; goto _test_eof; 
-	_test_eof9: cs = 9; goto _test_eof; 
-	_test_eof10: cs = 10; goto _test_eof; 
-	_test_eof11: cs = 11; goto _test_eof; 
-	_test_eof12: cs = 12; goto _test_eof; 
-	_test_eof13: cs = 13; goto _test_eof; 
-	_test_eof112: cs = 112; goto _test_eof; 
-	_test_eof113: cs = 113; goto _test_eof; 
-	_test_eof114: cs = 114; goto _test_eof; 
-	_test_eof115: cs = 115; goto _test_eof; 
-	_test_eof116: cs = 116; goto _test_eof; 
-	_test_eof14: cs = 14; goto _test_eof; 
-	_test_eof15: cs = 15; goto _test_eof; 
-	_test_eof16: cs = 16; goto _test_eof; 
-	_test_eof17: cs = 17; goto _test_eof; 
-	_test_eof18: cs = 18; goto _test_eof; 
-	_test_eof117: cs = 117; goto _test_eof; 
-	_test_eof118: cs = 118; goto _test_eof; 
-	_test_eof119: cs = 119; goto _test_eof; 
-	_test_eof120: cs = 120; goto _test_eof; 
-	_test_eof121: cs = 121; goto _test_eof; 
-	_test_eof122: cs = 122; goto _test_eof; 
-	_test_eof123: cs = 123; goto _test_eof; 
-	_test_eof124: cs = 124; goto _test_eof; 
-	_test_eof125: cs = 125; goto _test_eof; 
-	_test_eof126: cs = 126; goto _test_eof; 
-	_test_eof127: cs = 127; goto _test_eof; 
-	_test_eof128: cs = 128; goto _test_eof; 
-	_test_eof19: cs = 19; goto _test_eof; 
-	_test_eof20: cs = 20; goto _test_eof; 
-	_test_eof21: cs = 21; goto _test_eof; 
-	_test_eof22: cs = 22; goto _test_eof; 
-	_test_eof23: cs = 23; goto _test_eof; 
-	_test_eof24: cs = 24; goto _test_eof; 
-	_test_eof25: cs = 25; goto _test_eof; 
-	_test_eof26: cs = 26; goto _test_eof; 
-	_test_eof27: cs = 27; goto _test_eof; 
-	_test_eof28: cs = 28; goto _test_eof; 
-	_test_eof29: cs = 29; goto _test_eof; 
-	_test_eof30: cs = 30; goto _test_eof; 
-	_test_eof31: cs = 31; goto _test_eof; 
-	_test_eof32: cs = 32; goto _test_eof; 
-	_test_eof33: cs = 33; goto _test_eof; 
-	_test_eof34: cs = 34; goto _test_eof; 
-	_test_eof35: cs = 35; goto _test_eof; 
-	_test_eof36: cs = 36; goto _test_eof; 
-	_test_eof37: cs = 37; goto _test_eof; 
-	_test_eof38: cs = 38; goto _test_eof; 
-	_test_eof39: cs = 39; goto _test_eof; 
-	_test_eof40: cs = 40; goto _test_eof; 
-	_test_eof41: cs = 41; goto _test_eof; 
-	_test_eof42: cs = 42; goto _test_eof; 
-	_test_eof43: cs = 43; goto _test_eof; 
-	_test_eof44: cs = 44; goto _test_eof; 
-	_test_eof45: cs = 45; goto _test_eof; 
-	_test_eof46: cs = 46; goto _test_eof; 
-	_test_eof47: cs = 47; goto _test_eof; 
-	_test_eof48: cs = 48; goto _test_eof; 
-	_test_eof49: cs = 49; goto _test_eof; 
-	_test_eof50: cs = 50; goto _test_eof; 
-	_test_eof51: cs = 51; goto _test_eof; 
-	_test_eof52: cs = 52; goto _test_eof; 
-	_test_eof53: cs = 53; goto _test_eof; 
-	_test_eof54: cs = 54; goto _test_eof; 
-	_test_eof55: cs = 55; goto _test_eof; 
-	_test_eof56: cs = 56; goto _test_eof; 
-	_test_eof57: cs = 57; goto _test_eof; 
-	_test_eof58: cs = 58; goto _test_eof; 
-	_test_eof59: cs = 59; goto _test_eof; 
-	_test_eof60: cs = 60; goto _test_eof; 
-	_test_eof61: cs = 61; goto _test_eof; 
-	_test_eof62: cs = 62; goto _test_eof; 
-	_test_eof63: cs = 63; goto _test_eof; 
-	_test_eof64: cs = 64; goto _test_eof; 
-	_test_eof65: cs = 65; goto _test_eof; 
-	_test_eof66: cs = 66; goto _test_eof; 
-	_test_eof67: cs = 67; goto _test_eof; 
-	_test_eof68: cs = 68; goto _test_eof; 
-	_test_eof69: cs = 69; goto _test_eof; 
-	_test_eof70: cs = 70; goto _test_eof; 
-	_test_eof71: cs = 71; goto _test_eof; 
-	_test_eof72: cs = 72; goto _test_eof; 
-	_test_eof73: cs = 73; goto _test_eof; 
-	_test_eof74: cs = 74; goto _test_eof; 
-	_test_eof75: cs = 75; goto _test_eof; 
-	_test_eof76: cs = 76; goto _test_eof; 
-	_test_eof77: cs = 77; goto _test_eof; 
-	_test_eof78: cs = 78; goto _test_eof; 
-	_test_eof79: cs = 79; goto _test_eof; 
-	_test_eof80: cs = 80; goto _test_eof; 
-	_test_eof81: cs = 81; goto _test_eof; 
-	_test_eof82: cs = 82; goto _test_eof; 
-	_test_eof83: cs = 83; goto _test_eof; 
-	_test_eof84: cs = 84; goto _test_eof; 
-	_test_eof85: cs = 85; goto _test_eof; 
-	_test_eof86: cs = 86; goto _test_eof; 
-	_test_eof87: cs = 87; goto _test_eof; 
-	_test_eof88: cs = 88; goto _test_eof; 
-	_test_eof89: cs = 89; goto _test_eof; 
-	_test_eof129: cs = 129; goto _test_eof; 
-	_test_eof130: cs = 130; goto _test_eof; 
-	_test_eof131: cs = 131; goto _test_eof; 
-	_test_eof132: cs = 132; goto _test_eof; 
-	_test_eof133: cs = 133; goto _test_eof; 
-	_test_eof134: cs = 134; goto _test_eof; 
-	_test_eof90: cs = 90; goto _test_eof; 
-	_test_eof91: cs = 91; goto _test_eof; 
-	_test_eof92: cs = 92; goto _test_eof; 
-	_test_eof135: cs = 135; goto _test_eof; 
-	_test_eof93: cs = 93; goto _test_eof; 
-	_test_eof136: cs = 136; goto _test_eof; 
-	_test_eof137: cs = 137; goto _test_eof; 
-	_test_eof138: cs = 138; goto _test_eof; 
-	_test_eof139: cs = 139; goto _test_eof; 
-	_test_eof140: cs = 140; goto _test_eof; 
-	_test_eof141: cs = 141; goto _test_eof; 
-	_test_eof142: cs = 142; goto _test_eof; 
-	_test_eof143: cs = 143; goto _test_eof; 
-	_test_eof144: cs = 144; goto _test_eof; 
-	_test_eof145: cs = 145; goto _test_eof; 
-	_test_eof94: cs = 94; goto _test_eof; 
-	_test_eof95: cs = 95; goto _test_eof; 
-	_test_eof96: cs = 96; goto _test_eof; 
-	_test_eof97: cs = 97; goto _test_eof; 
-	_test_eof98: cs = 98; goto _test_eof; 
-	_test_eof99: cs = 99; goto _test_eof; 
-	_test_eof146: cs = 146; goto _test_eof; 
-	_test_eof147: cs = 147; goto _test_eof; 
-	_test_eof148: cs = 148; goto _test_eof; 
-	_test_eof149: cs = 149; goto _test_eof; 
-	_test_eof150: cs = 150; goto _test_eof; 
-	_test_eof151: cs = 151; goto _test_eof; 
-	_test_eof152: cs = 152; goto _test_eof; 
-	_test_eof153: cs = 153; goto _test_eof; 
-	_test_eof154: cs = 154; goto _test_eof; 
-	_test_eof155: cs = 155; goto _test_eof; 
-	_test_eof100: cs = 100; goto _test_eof; 
-	_test_eof101: cs = 101; goto _test_eof; 
-	_test_eof102: cs = 102; goto _test_eof; 
-	_test_eof103: cs = 103; goto _test_eof; 
-	_test_eof104: cs = 104; goto _test_eof; 
-	_test_eof105: cs = 105; goto _test_eof; 
+	_test_eof109: cs = 109; goto _test_eof;
+	_test_eof110: cs = 110; goto _test_eof;
+	_test_eof111: cs = 111; goto _test_eof;
+	_test_eof112: cs = 112; goto _test_eof;
+	_test_eof113: cs = 113; goto _test_eof;
+	_test_eof114: cs = 114; goto _test_eof;
+	_test_eof1: cs = 1; goto _test_eof;
+	_test_eof2: cs = 2; goto _test_eof;
+	_test_eof3: cs = 3; goto _test_eof;
+	_test_eof4: cs = 4; goto _test_eof;
+	_test_eof5: cs = 5; goto _test_eof;
+	_test_eof6: cs = 6; goto _test_eof;
+	_test_eof7: cs = 7; goto _test_eof;
+	_test_eof8: cs = 8; goto _test_eof;
+	_test_eof9: cs = 9; goto _test_eof;
+	_test_eof10: cs = 10; goto _test_eof;
+	_test_eof11: cs = 11; goto _test_eof;
+	_test_eof12: cs = 12; goto _test_eof;
+	_test_eof13: cs = 13; goto _test_eof;
+	_test_eof115: cs = 115; goto _test_eof;
+	_test_eof116: cs = 116; goto _test_eof;
+	_test_eof117: cs = 117; goto _test_eof;
+	_test_eof118: cs = 118; goto _test_eof;
+	_test_eof119: cs = 119; goto _test_eof;
+	_test_eof14: cs = 14; goto _test_eof;
+	_test_eof15: cs = 15; goto _test_eof;
+	_test_eof16: cs = 16; goto _test_eof;
+	_test_eof17: cs = 17; goto _test_eof;
+	_test_eof18: cs = 18; goto _test_eof;
+	_test_eof120: cs = 120; goto _test_eof;
+	_test_eof121: cs = 121; goto _test_eof;
+	_test_eof122: cs = 122; goto _test_eof;
+	_test_eof123: cs = 123; goto _test_eof;
+	_test_eof124: cs = 124; goto _test_eof;
+	_test_eof125: cs = 125; goto _test_eof;
+	_test_eof126: cs = 126; goto _test_eof;
+	_test_eof127: cs = 127; goto _test_eof;
+	_test_eof128: cs = 128; goto _test_eof;
+	_test_eof129: cs = 129; goto _test_eof;
+	_test_eof130: cs = 130; goto _test_eof;
+	_test_eof131: cs = 131; goto _test_eof;
+	_test_eof19: cs = 19; goto _test_eof;
+	_test_eof20: cs = 20; goto _test_eof;
+	_test_eof21: cs = 21; goto _test_eof;
+	_test_eof22: cs = 22; goto _test_eof;
+	_test_eof23: cs = 23; goto _test_eof;
+	_test_eof24: cs = 24; goto _test_eof;
+	_test_eof25: cs = 25; goto _test_eof;
+	_test_eof26: cs = 26; goto _test_eof;
+	_test_eof27: cs = 27; goto _test_eof;
+	_test_eof28: cs = 28; goto _test_eof;
+	_test_eof29: cs = 29; goto _test_eof;
+	_test_eof30: cs = 30; goto _test_eof;
+	_test_eof31: cs = 31; goto _test_eof;
+	_test_eof32: cs = 32; goto _test_eof;
+	_test_eof33: cs = 33; goto _test_eof;
+	_test_eof34: cs = 34; goto _test_eof;
+	_test_eof35: cs = 35; goto _test_eof;
+	_test_eof36: cs = 36; goto _test_eof;
+	_test_eof37: cs = 37; goto _test_eof;
+	_test_eof38: cs = 38; goto _test_eof;
+	_test_eof39: cs = 39; goto _test_eof;
+	_test_eof40: cs = 40; goto _test_eof;
+	_test_eof41: cs = 41; goto _test_eof;
+	_test_eof42: cs = 42; goto _test_eof;
+	_test_eof43: cs = 43; goto _test_eof;
+	_test_eof44: cs = 44; goto _test_eof;
+	_test_eof45: cs = 45; goto _test_eof;
+	_test_eof46: cs = 46; goto _test_eof;
+	_test_eof47: cs = 47; goto _test_eof;
+	_test_eof48: cs = 48; goto _test_eof;
+	_test_eof49: cs = 49; goto _test_eof;
+	_test_eof50: cs = 50; goto _test_eof;
+	_test_eof51: cs = 51; goto _test_eof;
+	_test_eof52: cs = 52; goto _test_eof;
+	_test_eof53: cs = 53; goto _test_eof;
+	_test_eof54: cs = 54; goto _test_eof;
+	_test_eof55: cs = 55; goto _test_eof;
+	_test_eof56: cs = 56; goto _test_eof;
+	_test_eof57: cs = 57; goto _test_eof;
+	_test_eof58: cs = 58; goto _test_eof;
+	_test_eof59: cs = 59; goto _test_eof;
+	_test_eof60: cs = 60; goto _test_eof;
+	_test_eof61: cs = 61; goto _test_eof;
+	_test_eof62: cs = 62; goto _test_eof;
+	_test_eof63: cs = 63; goto _test_eof;
+	_test_eof64: cs = 64; goto _test_eof;
+	_test_eof65: cs = 65; goto _test_eof;
+	_test_eof66: cs = 66; goto _test_eof;
+	_test_eof67: cs = 67; goto _test_eof;
+	_test_eof68: cs = 68; goto _test_eof;
+	_test_eof69: cs = 69; goto _test_eof;
+	_test_eof70: cs = 70; goto _test_eof;
+	_test_eof71: cs = 71; goto _test_eof;
+	_test_eof72: cs = 72; goto _test_eof;
+	_test_eof73: cs = 73; goto _test_eof;
+	_test_eof74: cs = 74; goto _test_eof;
+	_test_eof75: cs = 75; goto _test_eof;
+	_test_eof76: cs = 76; goto _test_eof;
+	_test_eof77: cs = 77; goto _test_eof;
+	_test_eof78: cs = 78; goto _test_eof;
+	_test_eof79: cs = 79; goto _test_eof;
+	_test_eof80: cs = 80; goto _test_eof;
+	_test_eof81: cs = 81; goto _test_eof;
+	_test_eof82: cs = 82; goto _test_eof;
+	_test_eof83: cs = 83; goto _test_eof;
+	_test_eof84: cs = 84; goto _test_eof;
+	_test_eof85: cs = 85; goto _test_eof;
+	_test_eof86: cs = 86; goto _test_eof;
+	_test_eof87: cs = 87; goto _test_eof;
+	_test_eof88: cs = 88; goto _test_eof;
+	_test_eof89: cs = 89; goto _test_eof;
+	_test_eof132: cs = 132; goto _test_eof;
+	_test_eof133: cs = 133; goto _test_eof;
+	_test_eof134: cs = 134; goto _test_eof;
+	_test_eof135: cs = 135; goto _test_eof;
+	_test_eof136: cs = 136; goto _test_eof;
+	_test_eof137: cs = 137; goto _test_eof;
+	_test_eof90: cs = 90; goto _test_eof;
+	_test_eof91: cs = 91; goto _test_eof;
+	_test_eof92: cs = 92; goto _test_eof;
+	_test_eof138: cs = 138; goto _test_eof;
+	_test_eof93: cs = 93; goto _test_eof;
+	_test_eof94: cs = 94; goto _test_eof;
+	_test_eof95: cs = 95; goto _test_eof;
+	_test_eof96: cs = 96; goto _test_eof;
+	_test_eof139: cs = 139; goto _test_eof;
+	_test_eof140: cs = 140; goto _test_eof;
+	_test_eof141: cs = 141; goto _test_eof;
+	_test_eof142: cs = 142; goto _test_eof;
+	_test_eof143: cs = 143; goto _test_eof;
+	_test_eof144: cs = 144; goto _test_eof;
+	_test_eof145: cs = 145; goto _test_eof;
+	_test_eof146: cs = 146; goto _test_eof;
+	_test_eof147: cs = 147; goto _test_eof;
+	_test_eof148: cs = 148; goto _test_eof;
+	_test_eof97: cs = 97; goto _test_eof;
+	_test_eof98: cs = 98; goto _test_eof;
+	_test_eof99: cs = 99; goto _test_eof;
+	_test_eof100: cs = 100; goto _test_eof;
+	_test_eof101: cs = 101; goto _test_eof;
+	_test_eof102: cs = 102; goto _test_eof;
+	_test_eof149: cs = 149; goto _test_eof;
+	_test_eof150: cs = 150; goto _test_eof;
+	_test_eof151: cs = 151; goto _test_eof;
+	_test_eof152: cs = 152; goto _test_eof;
+	_test_eof153: cs = 153; goto _test_eof;
+	_test_eof154: cs = 154; goto _test_eof;
+	_test_eof155: cs = 155; goto _test_eof;
+	_test_eof156: cs = 156; goto _test_eof;
+	_test_eof157: cs = 157; goto _test_eof;
+	_test_eof158: cs = 158; goto _test_eof;
+	_test_eof103: cs = 103; goto _test_eof;
+	_test_eof104: cs = 104; goto _test_eof;
+	_test_eof105: cs = 105; goto _test_eof;
+	_test_eof106: cs = 106; goto _test_eof;
+	_test_eof107: cs = 107; goto _test_eof;
+	_test_eof108: cs = 108; goto _test_eof;
 
 	_test_eof: {}
 	if ( p == eof )
 	{
 	switch ( cs ) {
-	case 107: goto tr150;
-	case 108: goto tr152;
-	case 109: goto tr154;
-	case 110: goto tr155;
-	case 111: goto tr156;
+	case 110: goto tr153;
+	case 111: goto tr155;
+	case 112: goto tr157;
+	case 113: goto tr158;
+	case 114: goto tr159;
 	case 1: goto tr0;
 	case 2: goto tr0;
 	case 3: goto tr0;
@@ -3067,28 +3120,28 @@ case 105:
 	case 11: goto tr0;
 	case 12: goto tr0;
 	case 13: goto tr0;
-	case 112: goto tr160;
-	case 113: goto tr160;
-	case 114: goto tr160;
-	case 115: goto tr160;
-	case 116: goto tr155;
+	case 115: goto tr163;
+	case 116: goto tr163;
+	case 117: goto tr163;
+	case 118: goto tr163;
+	case 119: goto tr158;
 	case 14: goto tr16;
 	case 15: goto tr16;
 	case 16: goto tr16;
 	case 17: goto tr16;
 	case 18: goto tr16;
-	case 117: goto tr166;
-	case 118: goto tr166;
-	case 119: goto tr166;
-	case 120: goto tr166;
-	case 121: goto tr155;
-	case 122: goto tr154;
-	case 123: goto tr170;
-	case 124: goto tr170;
-	case 125: goto tr170;
-	case 126: goto tr170;
-	case 127: goto tr174;
-	case 128: goto tr175;
+	case 120: goto tr169;
+	case 121: goto tr169;
+	case 122: goto tr169;
+	case 123: goto tr169;
+	case 124: goto tr158;
+	case 125: goto tr157;
+	case 126: goto tr173;
+	case 127: goto tr173;
+	case 128: goto tr173;
+	case 129: goto tr173;
+	case 130: goto tr177;
+	case 131: goto tr178;
 	case 19: goto tr23;
 	case 20: goto tr23;
 	case 21: goto tr23;
@@ -3160,50 +3213,53 @@ case 105:
 	case 87: goto tr23;
 	case 88: goto tr23;
 	case 89: goto tr23;
-	case 129: goto tr184;
-	case 130: goto tr184;
-	case 131: goto tr186;
-	case 132: goto tr174;
-	case 133: goto tr174;
-	case 134: goto tr174;
+	case 132: goto tr187;
+	case 133: goto tr187;
+	case 134: goto tr189;
+	case 135: goto tr177;
+	case 136: goto tr177;
+	case 137: goto tr177;
 	case 90: goto tr100;
 	case 91: goto tr100;
 	case 92: goto tr100;
-	case 135: goto tr191;
-	case 93: goto tr104;
-	case 136: goto tr174;
-	case 137: goto tr174;
-	case 138: goto tr174;
-	case 139: goto tr174;
-	case 140: goto tr174;
-	case 141: goto tr174;
-	case 142: goto tr174;
-	case 143: goto tr174;
-	case 144: goto tr174;
-	case 145: goto tr174;
-	case 94: goto tr100;
-	case 95: goto tr100;
-	case 96: goto tr100;
-	case 97: goto tr16;
-	case 98: goto tr16;
-	case 99: goto tr16;
-	case 146: goto tr191;
-	case 147: goto tr191;
-	case 148: goto tr191;
-	case 149: goto tr191;
-	case 150: goto tr174;
-	case 151: goto tr174;
-	case 152: goto tr205;
-	case 153: goto tr207;
-	case 154: goto tr209;
-	case 155: goto tr211;
+	case 138: goto tr194;
+	case 93: goto tr107;
+	case 94: goto tr16;
+	case 95: goto tr16;
+	case 96: goto tr16;
+	case 139: goto tr177;
+	case 140: goto tr177;
+	case 141: goto tr177;
+	case 142: goto tr177;
+	case 143: goto tr177;
+	case 144: goto tr177;
+	case 145: goto tr177;
+	case 146: goto tr177;
+	case 147: goto tr177;
+	case 148: goto tr177;
+	case 97: goto tr100;
+	case 98: goto tr100;
+	case 99: goto tr100;
+	case 100: goto tr16;
+	case 101: goto tr16;
+	case 102: goto tr16;
+	case 149: goto tr194;
+	case 150: goto tr194;
+	case 151: goto tr194;
+	case 152: goto tr194;
+	case 153: goto tr177;
+	case 154: goto tr177;
+	case 155: goto tr208;
+	case 156: goto tr210;
+	case 157: goto tr212;
+	case 158: goto tr214;
 	}
 	}
 
 	_out: {}
 	}
 
-#line 527 "ext/wikitext/wikitext_ragel.rl"
+#line 533 "wikitext_ragel.rl"
     if (cs == wikitext_error)
         rb_raise(eWikitextParserError, "failed before finding a token");
     else if (out->type == NO_TOKEN)

--- a/ext/wikitext/wikitext_ragel.h
+++ b/ext/wikitext/wikitext_ragel.h
@@ -23,4 +23,4 @@
 
 #include "token.h"
 
-void next_token(token_t *out, token_t *last_token, char *p, char *pe);
+void next_token(token_t *out, token_t *last_token, unsigned char *p, unsigned char *pe);

--- a/ext/wikitext/wikitext_ragel.rl
+++ b/ext/wikitext/wikitext_ragel.rl
@@ -40,6 +40,7 @@
 
 %%{
     machine wikitext;
+    alphtype unsigned char;
 
     action mark
     {
@@ -487,7 +488,7 @@
 // pass in the last token because that's useful for the scanner to know
 // p data pointer (required by Ragel machine); overriden with contents of last_token if supplied
 // pe data end pointer (required by Ragel machine)
-void next_token(token_t *out, token_t *last_token, char *p, char *pe)
+void next_token(token_t *out, token_t *last_token, unsigned char *p, unsigned char *pe)
 {
     int last_token_type = NO_TOKEN;
     if (last_token)
@@ -515,11 +516,11 @@ void next_token(token_t *out, token_t *last_token, char *p, char *pe)
         return;
     }
 
-    char    *mark;      // for manual backtracking
-    char    *eof = pe;  // required for backtracking (longest match determination)
+    unsigned char *mark;      // for manual backtracking
+    unsigned char *eof = pe;  // required for backtracking (longest match determination)
     int     cs;         // current state (standard Ragel)
-    char    *ts;        // token start (scanner)
-    char    *te;        // token end (scanner)
+    unsigned char *ts;        // token start (scanner)
+    unsigned char *te;        // token end (scanner)
     int     act;        // identity of last patterned matched (scanner)
     %% write init;
     %% write exec;

--- a/ext/wikitext/wikitext_ragel.rl
+++ b/ext/wikitext/wikitext_ragel.rl
@@ -79,7 +79,13 @@
     domain              = (alnum+ '.')+ tld ;
     mail                = user '@' domain ;
 
-    uri_chars           = (alnum | [@$&'(\*\+=%_~/#] | '-')+ ;
+    # UTF-8 character sequences for international characters in URIs
+    utf8_2byte          = 0xc2..0xdf 0x80..0xbf ;
+    utf8_3byte          = 0xe0..0xef 0x80..0xbf 0x80..0xbf ;
+    utf8_4byte          = 0xf0..0xf4 0x80..0xbf 0x80..0xbf 0x80..0xbf ;
+    utf8_char           = utf8_2byte | utf8_3byte | utf8_4byte ;
+
+    uri_chars           = (alnum | [@$&'(\*\+=%_~/#] | '-' | utf8_char)+ ;
     special_uri_chars   = ([:!\(\),;\.\?])+ ;
     uri                 = ('mailto:'i mail) |
                           (('http'i [sS]? '://' | 'ftp://'i | 'svn://'i) uri_chars (special_uri_chars uri_chars)*) ;

--- a/spec/external_link_spec.rb
+++ b/spec/external_link_spec.rb
@@ -211,9 +211,14 @@ describe Wikitext::Parser, 'external links' do
     @parser.parse(%Q{[http://google.com/ Google &#x20ac;]}).should == expected
   end
 
-  it 'should convert non-ASCII characters in the link text into entities' do
-    expected = %Q{<p><a href="http://google.com/" class="external">Google &#x20ac;</a></p>\n}
+  it 'should preserve non-ASCII characters in the link text' do
+    expected = %Q{<p><a href="http://google.com/" class="external">Google €</a></p>\n}
     @parser.parse(%Q{[http://google.com/ Google €]}).should == expected
+  end
+
+  it 'should preserve Unicode characters in links' do
+    expected = %Q{<p><a href="https://ru.wikipedia.org/wiki/Русская_Википедия" class="external">ВИКИПЕДИЯ</a></p>\n}
+    @parser.parse('[https://ru.wikipedia.org/wiki/Русская_Википедия ВИКИПЕДИЯ]').should == expected
   end
 
   it 'should pass through unexpected external link end tokens literally' do

--- a/spec/internal_link_spec.rb
+++ b/spec/internal_link_spec.rb
@@ -97,7 +97,7 @@ describe Wikitext::Parser, 'internal links (space to underscore off)' do
   end
 
   it 'should handle mixed scenarios (quotes, ampersands, non-ASCII characers)' do
-    expected = %Q{<p><a href="/wiki/foo%2c%20%22bar%22%20%26%20baz%20%e2%82%ac">foo, &quot;bar&quot; &amp; baz &#x20ac;</a></p>\n}
+    expected = %Q{<p><a href="/wiki/foo%2c%20%22bar%22%20%26%20baz%20%e2%82%ac">foo, &quot;bar&quot; &amp; baz €</a></p>\n}
     @parser.parse('[[foo, "bar" & baz €]]').should == expected
   end
 
@@ -226,13 +226,13 @@ describe Wikitext::Parser, 'internal links (space to underscore off)' do
 
     it 'handles link targets with encoded parts (Proc object version)' do
       link_proc = proc { |target| target == 'información' ? 'redlink' : nil }
-      expected = %Q{<p><a href="/wiki/informaci%c3%b3n" class="redlink">informaci&#x00f3;n</a> <a href="/wiki/bar">bar</a></p>\n}
+      expected = %Q{<p><a href="/wiki/informaci%c3%b3n" class="redlink">información</a> <a href="/wiki/bar">bar</a></p>\n}
       @parser.parse('[[información]] [[bar]]', link_proc: link_proc).should == expected
     end
 
     it 'should handle link targets with encoded parts (lambda version)' do
       link_proc = lambda { |target| target == 'información' ? 'redlink' : nil }
-      expected = %Q{<p><a href="/wiki/informaci%c3%b3n" class="redlink">informaci&#x00f3;n</a> <a href="/wiki/bar">bar</a></p>\n}
+      expected = %Q{<p><a href="/wiki/informaci%c3%b3n" class="redlink">información</a> <a href="/wiki/bar">bar</a></p>\n}
       @parser.parse('[[información]] [[bar]]', :link_proc => link_proc).should == expected
     end
   end
@@ -655,7 +655,7 @@ describe Wikitext::Parser, 'internal links (space to underscore on)' do
   end
 
   it 'should handle mixed scenarios (quotes, ampersands, non-ASCII characers)' do
-    expected = %Q{<p><a href="/wiki/foo%2c_%22bar%22_%26_baz_%e2%82%ac">foo, &quot;bar&quot; &amp; baz &#x20ac;</a></p>\n}
+    expected = %Q{<p><a href="/wiki/foo%2c_%22bar%22_%26_baz_%e2%82%ac">foo, &quot;bar&quot; &amp; baz €</a></p>\n}
     @parser.parse('[[foo, "bar" & baz €]]').should == expected
   end
 
@@ -764,13 +764,13 @@ describe Wikitext::Parser, 'internal links (space to underscore on)' do
 
     it 'should handle link targets with encoded parts (Proc object version)' do
       link_proc = Proc.new { |target| target == 'información' ? 'redlink' : nil }
-      expected = %Q{<p><a href="/wiki/informaci%c3%b3n" class="redlink">informaci&#x00f3;n</a> <a href="/wiki/bar">bar</a></p>\n}
+      expected = %Q{<p><a href="/wiki/informaci%c3%b3n" class="redlink">información</a> <a href="/wiki/bar">bar</a></p>\n}
       @parser.parse('[[información]] [[bar]]', :link_proc => link_proc).should == expected
     end
 
     it 'handles link targets with encoded parts (lambda version)' do
       link_proc = lambda { |target| target == 'información' ? 'redlink' : nil }
-      expected = %Q{<p><a href="/wiki/informaci%c3%b3n" class="redlink">informaci&#x00f3;n</a> <a href="/wiki/bar">bar</a></p>\n}
+      expected = %Q{<p><a href="/wiki/informaci%c3%b3n" class="redlink">información</a> <a href="/wiki/bar">bar</a></p>\n}
       @parser.parse('[[información]] [[bar]]', link_proc: link_proc).should == expected
     end
   end

--- a/spec/link_sanitizing_spec.rb
+++ b/spec/link_sanitizing_spec.rb
@@ -92,12 +92,12 @@ describe Wikitext, 'sanitizing a link target' do
     Wikitext::Parser.sanitize_link_target('hello & goodbye').should == 'hello &amp; goodbye'
   end
 
-  it 'should convert non-ASCII hexadecimal entities' do
-    Wikitext::Parser.sanitize_link_target('cañon').should == 'ca&#x00f1;on'
+  it 'should preserve non-ASCII characters' do
+    Wikitext::Parser.sanitize_link_target('cañon').should == 'cañon'
   end
 
   it 'should handle mixed scenarios (ampersands, double-quotes and non-ASCII)' do
-    Wikitext::Parser.sanitize_link_target('foo, "bar" & baz €').should == 'foo, &quot;bar&quot; &amp; baz &#x20ac;'
+    Wikitext::Parser.sanitize_link_target('foo, "bar" & baz €').should == 'foo, &quot;bar&quot; &amp; baz €'
   end
 
   # here we're exercising the wiki_utf8_to_utf32 function


### PR DESCRIPTION
On ARM (Graviton), char is unsigned by default while x86 uses signed char. The Ragel-generated UTF-8 byte comparisons were breaking on ARM because the state machine expected signed comparisons (e.g., -62 for 0xC2) but received unsigned values (194), causing all UTF-8 parsing to fail with "failed before finding a token" errors.

Changed all char pointers to unsigned char throughout the parser to ensure consistent byte value interpretation across architectures. This makes the alphtype directive in the Ragel grammar match the actual C types used.